### PR TITLE
Add a new job for building and releasing the Intel ifx debug executable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -249,11 +249,79 @@ jobs:
           name: intel-${{ steps.build_exe.outputs.os }}
           path: ${{ steps.build_exe.outputs.exez }}
 
+##### Build with Intel ifx debug
+
+  build-intel-ifx-debug:
+    runs-on: windows-latest
+    needs:
+      - version
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: '${{ github.event.inputs.rev }}'
+
+      - name: Install Compiler
+        uses: fortran-lang/setup-fortran@v1
+        id: setup-fortran
+        with:
+          compiler: intel
+          version: '2024.1'
+
+      - name: Download version
+        uses: actions/download-artifact@v4
+        with:
+          name: release_tag
+
+      - name: Build SWAT+ (Intel ifx Debug)
+        id: build_exe
+        run: |
+          echo ${{ env.FC }}
+          cmake --version
+
+          RELEASE_VERSION=`cat v.txt`
+          os="$RUNNER_OS"
+
+          cmake -B build -G "MinGW Makefiles" \
+            -D CMAKE_Fortran_COMPILER="C:\Program Files (x86)\Intel\oneAPI\compiler\2024.1\bin\ifx.exe" \
+            -D TAG=$RELEASE_VERSION \
+            -D CMAKE_BUILD_TYPE=Debug \
+            --preset ifx_debug
+
+          # compile
+          cmake --build build --parallel 4
+
+          exebase=`basename -s .exe build/swatplus-*`
+          exez="${exebase}.zip"
+          exe=`ls build/swatplus-*.exe`
+
+          echo $exe
+          echo $exez
+          echo $os
+
+          echo "exe=$exe" >> $GITHUB_OUTPUT
+          echo "exez=$exez" >> $GITHUB_OUTPUT
+          echo "os=$os" >> $GITHUB_OUTPUT
+
+          ls -hl build/swatplus-*
+          file build/swatplus-*
+
+          (cd build && zip ../$exez swatplus-*)
+
+        shell: bash
+
+      - name: upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: intel-ifx-debug-${{ steps.build_exe.outputs.os }}
+          path: ${{ steps.build_exe.outputs.exez }}
+
 ##### Create a new release with all zip files
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: [ build-gnu, build-intel ]
+    needs: [ build-gnu, build-intel, build-intel-ifx-debug ]
 
     steps:
     - name: Download GNU Linux
@@ -286,6 +354,11 @@ jobs:
       with:
         name: intel-macOS
 
+    - name: Download Intel ifx Debug Windows
+      uses: actions/download-artifact@v4
+      with:
+        name: intel-ifx-debug-Windows
+
     - name: Download version
       uses: actions/download-artifact@v4
       with:
@@ -309,6 +382,3 @@ jobs:
         name:  ${{ steps.read_ver.outputs.rv }}
         files: swatplus-*
         generate_release_notes: true
-
-
-


### PR DESCRIPTION
* **Build with Intel ifx debug**
  - Add a new job `build-intel-ifx-debug` to build the Intel ifx debug executable using the `ifx_debug` preset
  - Upload the resulting Intel ifx debug executable as an artifact

* **Release**
  - Update the `release` job to include the Intel ifx debug executable in the release artifacts