### PR TITLE
Merge 0417

### DIFF
--- a/src/mgt_newtillmix.f90
+++ b/src/mgt_newtillmix.f90
@@ -48,10 +48,10 @@
       real :: dtil = 0.                !mm             |depth of mixing
       real :: frac_mixed = 0.          !               |
       real :: frac_non_mixed = 0.      !               |
-      real :: sol_mass(soil(jj)%nly)    !              |mass of the soil layer
-      real :: sol_msm(soil(jj)%nly)     !              |sol_mass mixed
-      real :: sol_msn(soil(jj)%nly)     !              |sol_mass not mixed 
-      real :: frac_dep(soil(jj)%nly)    !              |fraction of soil layer in tillage depth
+      real :: sol_mass(5)    !              |mass of the soil layer
+      real :: sol_msm(5)     !              |sol_mass mixed
+      real :: sol_msn(5)     !              |sol_mass not mixed 
+      real :: frac_dep(5)    !              |fraction of soil layer in tillage depth
       real :: frac1 = 0.
       real :: frac2 = 0.
       real :: mix_clay
@@ -131,7 +131,6 @@
         ! added by Armen 09/10/2010 next line only
         if (dtil < 10.0) dtil = 11.0
         do l = 1, soil(jj)%nly
-
           if (soil(jj)%phys(l)%d <= dtil) then
             !! msm = mass of soil mixed for the layer
             !! msn = mass of soil not mixed for the layer       
@@ -154,9 +153,9 @@
           mix_sw = mix_sw + frac_mixed * soil(jj)%phys(l)%st
           mix_bd = mix_bd + frac_mixed * soil(jj)%phys(l)%bd
           mix_rock = mix_rock + frac_mixed * soil(jj)%phys(l)%rock
-          mix_sand = mix_sand + frac_mixed * soil(jj)%phys(l)%sand
-          mix_silt = mix_silt + frac_mixed * soil(jj)%phys(l)%silt
-          mix_clay = mix_clay + frac_mixed * soil(jj)%phys(l)%clay
+          mix_sand = mix_sand + frac_mixed * soil(jj)%phys(l)%sand * sol_mass(l) / 100.
+          mix_silt = mix_silt + frac_mixed * soil(jj)%phys(l)%silt * sol_mass(l) / 100.
+          mix_clay = mix_clay + frac_mixed * soil(jj)%phys(l)%clay * sol_mass(l) / 100.
           
           mix_mn = mix_mn + frac_mixed * soil1(jj)%mn(l)
           mix_mp = mix_mp + frac_mixed * soil1(jj)%mp(l)
@@ -177,6 +176,7 @@
           do l = 1, soil(jj)%nly
             ! reconstitute each soil layer 
             frac_non_mixed = sol_msn(l) / sol_mass(l)
+            frac_mixed = 1. - frac_non_mixed
             
             soil1(jj)%mn(l) = frac_non_mixed * soil1(jj)%mn(l) + frac_dep(l) * mix_mn
             ! print*, "in mgt_newtill_mix", l, soil1(jj)%mn(l)%no3
@@ -194,12 +194,16 @@
             soil1(jj)%man(l) = frac_non_mixed * soil1(jj)%man(l) + frac_dep(l) * mix_org%man
             soil1(jj)%water(l) = frac_non_mixed * soil1(jj)%water(l) + frac_dep(l) * mix_org%water
             
-            soil(jj)%phys(l)%clay = frac_non_mixed * soil(jj)%phys(l)%clay + frac_mixed * mix_clay
-            soil(jj)%phys(l)%silt = frac_non_mixed * soil(jj)%phys(l)%silt + frac_mixed * mix_silt
-            soil(jj)%phys(l)%sand = frac_non_mixed * soil(jj)%phys(l)%sand + frac_mixed * mix_sand
-            soil(jj)%phys(l)%st = frac_non_mixed * soil(jj)%phys(l)%st + frac_mixed * mix_sw
-            soil(jj)%phys(l)%bd = frac_non_mixed * soil(jj)%phys(l)%bd + frac_mixed * mix_bd
-            soil(jj)%phys(l)%rock = frac_non_mixed * soil(jj)%phys(l)%rock + frac_mixed * mix_rock
+            soil(jj)%phys(l)%clay = 100. / sol_mass(l) * (frac_non_mixed * soil(jj)%phys(l)%clay * sol_mass(l) / 100. &
+                                                                                             + frac_dep(l) * mix_clay)
+            soil(jj)%phys(l)%silt = 100. / sol_mass(l) * (frac_non_mixed * soil(jj)%phys(l)%silt * sol_mass(l) / 100. &
+                                                                                             + frac_dep(l) * mix_silt)
+            soil(jj)%phys(l)%sand = 100. / sol_mass(l) * (frac_non_mixed * soil(jj)%phys(l)%sand * sol_mass(l) / 100. &
+                                                                                             + frac_dep(l) * mix_sand)
+            soil(jj)%phys(l)%rock = 100. / sol_mass(l) * (frac_non_mixed * soil(jj)%phys(l)%rock * sol_mass(l) / 100. &
+                                                                                             + frac_dep(l) * mix_rock)
+            soil(jj)%phys(l)%st = frac_non_mixed * soil(jj)%phys(l)%st + frac_dep(l) * mix_sw
+            !soil(jj)%phys(l)%bd = frac_non_mixed * soil(jj)%phys(l)%bd + frac_dep(l) * mix_bd
 
             !do k = 1, npmx
             !  cs_soil(jj)%ly(l)%pest(k) = cs_soil(jj)%ly(l)%pest(k) * frac_non_mixed + smix(20+k) * frac_dep(l)


### PR DESCRIPTION
Dimension Adjustment: Changed sol_mass, sol_msm, sol_msn, and frac_dep arrays to use a fixed size of 5 instead of dynamically depending on soil(jj)%nly.
Normalization Updates: Incorporated sol_mass normalization for soil property calculations such as mix_sand, mix_silt, and mix_clay.
Added Complementary Variable: Explicitly calculated frac_mixed as 1. - frac_non_mixed for better readability.
Refactored Soil Property Updates: Updated logic for soil(jj)%phys(l) properties to include normalization by sol_mass and frac_dep.