### PR TITLE
Src 05132025

### DIFF
--- a/src/command.f90
+++ b/src/command.f90
@@ -335,6 +335,7 @@
               
               rec_d(irec) = ob(icmd)%hd(1)
 
+              obcs(icmd)%hd(1) = hin_csz
               if(cs_db%num_salts > 0) call recall_salt(irec) !rtb salt
               if(cs_db%num_cs > 0) call recall_cs(irec) !rtb cs
               

--- a/src/res_control.f90
+++ b/src/res_control.f90
@@ -28,6 +28,7 @@
 
       ht1 = ob(icmd)%hin    !! set incoming flow
       ht2 = resz            !! zero outgoing flow
+      hcs2 = hin_csz        !! zero outgoing constituents
 
       if (time%yrc > res_hyd(jres)%iyres .or. (time%mo >= res_hyd(jres)%mores   &
                                    .and. time%yrc == res_hyd(jres)%iyres)) then
@@ -178,14 +179,9 @@
       else
         !! reservoir has not been constructed yet
         ob(icmd)%hd(1) = ob(icmd)%hin
+        obcs(icmd)%hd(1) = obcs(icmd)%hin(1)
       end if
 
-  !!!! for Luis only    
-      !if (jres == 1) then
-      !  write (7777,*) time%day, time%yrc, jres, res(jres)%flo, ht1%flo, ht2%flo,   &
-      !                                           res(jres)%sed, ht1%sed, ht2%sed
-      !end if
-  !!!! for Luis only
       
       return
       end subroutine res_control

--- a/src/ru_control.f90
+++ b/src/ru_control.f90
@@ -84,6 +84,7 @@
         ht3 = hz
         ht4 = hz
         ht5 = hz
+        hcs1 = hin_csz
         delrto = hz
         
         sumfrac = sumfrac + ru_elem(ise)%frac

--- a/src/sd_channel_control3.f90
+++ b/src/sd_channel_control3.f90
@@ -120,7 +120,8 @@
       ht1 = ob(icmd)%hin
       
       !! zero outgoing flow and sediment - ht2
-      ht2 = hz 
+      ht2 = hz
+      obcs(icmd)%hd(:) = hin_csz
       
       !! zero daily in/out morphology and sediment budget output
       ch_sed_bud(ich) = ch_sed_budz


### PR DESCRIPTION
Pull request for handling zero outgoing constituents in the hydrological model. The changes ensure consistent initialization and assignment of this variable in relevant subroutines.


* `src/command.f90` (`subroutine command`): Added assignment of `hin_csz` to `obcs(icmd)%hd(1)` to initialize constituent handling.
* `src/res_control.f90` (`subroutine res_control`): 
  - Added `hcs2 = hin_csz` to set zero outgoing constituents.
  - Updated `obcs(icmd)%hd(1)` assignment to use `obcs(icmd)%hin(1)` for consistency during unconstructed reservoir handling. Removed commented-out debugging code for clarity.
* `src/ru_control.f90` (`subroutine ru_control`): Added `hcs1 = hin_csz` to initialize zero outgoing constituents in the rural control subroutine.
* `src/sd_channel_control3.f90` (`subroutine sd_channel_control3`): Added assignment of `hin_csz` to `obcs(icmd)%hd(:)` for zeroing outgoing constituents in channel control.