### PR TITLE
Read manure defaults from CSV

### DIFF
--- a/src/fert_parm_read.f90
+++ b/src/fert_parm_read.f90
@@ -64,11 +64,16 @@ subroutine fert_parm_read
               allocate (fertdb_cbn(0:imax))
               do it = 1, imax
                 read (107,*,iostat=eof) fertdb_cbn(it)%base, fertdb_cbn(it)%wc, &
-                      fertdb_cbn(it)%omad%manure_name, fertdb_cbn(it)%pest, fertdb_cbn(it)%path, &
+                      fertdb_cbn(it)%manure_content%manure_region, &
+                      fertdb_cbn(it)%manure_content%manure_source, &
+                      fertdb_cbn(it)%manure_content%manure_type, &
+                      fertdb_cbn(it)%pest, fertdb_cbn(it)%path, &
                       fertdb_cbn(it)%salt, fertdb_cbn(it)%hmet, fertdb_cbn(it)%cs
-                  if (eof < 0) exit
-                  !-- Assign fertdb_cbn to fertdb for compatibility with existing code --- !
-                  fertdb(it) = fertdb_cbn(it)%base
+                if (eof < 0) exit
+                fertdb_cbn(it)%manure_content%manure_name = trim(fertdb_cbn(it)%manure_content%manure_region)//trim(fertdb_cbn(it)%manure_content%manure_source)//"_"// &
+                     trim(fertdb_cbn(it)%manure_content%manure_type)
+                !-- Assign fertdb_cbn to fertdb for compatibility with existing code --- !
+                fertdb(it) = fertdb_cbn(it)%base
               end do
             endif
           enddo

--- a/src/fertilizer_data_module.f90
+++ b/src/fertilizer_data_module.f90
@@ -23,30 +23,37 @@
       
 
       
-      type manure_data
-        character(len=16) :: manure_name = " "
-      !  character(len=16), dimension(:),allocatable :: path = " "
-      !  character(len=16), dimension(:),allocatable :: antibiotic = " "
-      end type manure_data
-      type (manure_data), dimension(:),allocatable :: manure_db
-      
-      type :: omad_input
+      type :: manure_content
+        ! Identifier used to crosswalk fertilizer entries
         character(len=32) :: manure_name = " "  ! e.g., BFSD
-        character(len=64) :: manure_desc = " "  ! e.g., Beef solid unsurfaced lot
-        real :: omadtyp = 0.0    ! Type flag, e.g., 1.5
-        real :: astgc = 0.0      ! gC/m2/ton or gC/m2/gal
-        real :: astlbl = 0.0     ! May be a label/unused
-        real :: astlig = 0.0     ! Lignin fraction
-        real :: cn = 0.0         ! C:N ratio
-        real :: cp = 0.0         ! C:P ratio
-        real :: cs = 0.0         ! C:S ratio
-      end type omad_input
-      type(omad_input), allocatable, save :: omad_db(:)
+        ! additional attributes from fp5-manure-content-defaults-swat.csv
+        character(len=32) :: manure_region = " "
+        character(len=32) :: manure_source = " "
+        character(len=32) :: manure_type = " "
+        real :: pct_moisture = 0.0
+        real :: pct_solids = 0.0
+        real :: total_c = 0.0
+        real :: total_n = 0.0
+        real :: inorganic_n = 0.0
+        real :: organic_n = 0.0
+        real :: total_p2o5 = 0.0
+        real :: inorganic_p2o5 = 0.0
+        real :: organic_p2o5 = 0.0
+        real :: inorganic_p = 0.0
+        real :: organic_p = 0.0
+        real :: solids = 0.0
+        real :: water = 0.0
+        character(len=32) :: units = " "
+        integer :: sample_size = 0
+        character(len=32) :: summary_level = " "
+        character(len=64) :: data_source = " "
+      end type manure_content
+      type(manure_content), allocatable, save :: manure_db(:)
       
       type fertilizer_carbon_db
         type(fertilizer_db) :: base     !! base fertilizer data
         real :: wc = 0.0                 !! kg H2O/kg frt     |frac of fert which is water (H2O)
-        type (omad_input) :: omad
+        type (manure_content) :: manure_content
         character(len=16) :: pest = ""  !! pest.man name
         character(len=16) :: path = ""  !! path.man name
         character(len=16) :: salt = ""  !! salt.man name

--- a/src/manure_parm_read.f90
+++ b/src/manure_parm_read.f90
@@ -7,104 +7,77 @@
       implicit none
    
       integer :: it = 0                     !!none      |counter
-      character (len=80) :: titldum = ""    !!          |title of file
-      character (len=80) :: header = ""     !!          |header of file
-      character (len=16) :: omad_line = ""  !!          |omad line dummy variable
+      character (len=256) :: header = ""     !!          |header of file
+      character (len=256) :: csv_line = ""  !! line for csv file
       integer :: eof = 0                    !!          |end of file
       integer :: unit = 107                 !!          |unit number for file
       integer :: imax = 0                   !!none      |determine max number for array (imax) and total number in file
-      integer :: mfrt = 0                   !!          |
       logical :: i_exist                    !!none      |check to determine if file exists
       integer :: i
-      
-      
+
+
       eof = 0
       imax = 0
-      mfrt = 0
+
       
-      inquire (file="manure.frt", exist=i_exist)
-      if (.not. i_exist .or. "manure.frt" == "null") then
-         allocate (manure_db(0:0))
+      !! --- inquire if fp5-manure-content-defaults-swat.csv exists --- !!
+      inquire (file="fp5-manure-content-defaults-swat.csv", exist=i_exist)
+      if (.not. i_exist .or. "fp5-manure-content-defaults-swat.csv" == "null") then
+          allocate (manure_db(0:0))
+          db_mx%manureparm = 0
       else
-      do  
-        open (107,file="manure.frt")
-        read (107,*,iostat=eof) titldum
-        if (eof < 0) exit
-        read (107,*,iostat=eof) header
-        if (eof < 0) exit
-           do while (eof == 0) 
-             read (107,*,iostat=eof) titldum
-             if (eof < 0) exit
-             imax = imax + 1
-           end do
-           
-        allocate (manure_db(0:imax))
-        
-        rewind (107)
-        read (107,*,iostat=eof) titldum
-        if (eof < 0) exit
-        read (107,*,iostat=eof) header
-        if (eof < 0) exit
-        
-        do it = 1, imax
-          read (107,*,iostat=eof) manure_db(it)
-          if (eof < 0) exit
-        end do
-       exit
-      enddo
-      endif
-      
-      db_mx%manureparm  = imax 
-      close (107)
-      
-      !! reset counters for omad database
-      eof = 0
-      imax = 0
-      
-      !! --- inquire if omad.txt exists --- !!
-      inquire (file="omad.txt", exist=i_exist)
-      if (.not. i_exist .or. "omad.txt" == "null") then
-          allocate (omad_db(0:0))
-      else
-            open (unit,file="omad.txt")
+            open (unit,file="fp5-manure-content-defaults-swat.csv")
+            read(unit,'(A)',iostat=eof) header   ! skip header line
             do while (eof == 0)
-                read (unit,*,iostat=eof) omad_line ! read dummy omad line
+                read(unit,'(A)',iostat=eof) csv_line
                 if (eof < 0) exit
                 imax = imax + 1
             end do
-            !! ensure that imax is a multiple of 8 and omad is in proper format 
-            if (mod(imax, 8) /= 0) then
-                ! if not then write error message to diagnostics.out file and allocate empty omad_db
-                write (9001, *) "Error: OMAD file does not have a multiple of 8 lines / not in proper format"
-                allocate (omad_db(0:0))       
-            else
-                imax = imax / 8
-                allocate (omad_db(0:imax))
-                rewind (unit)
-                !! read the omad database
-                do it = 1, imax
-                    read(unit, *, iostat=eof) omad_db(it)%manure_name, omad_db(it)%manure_desc
-                    read(unit, *, iostat=eof) omad_db(it)%omadtyp
-                    read(unit, *, iostat=eof) omad_db(it)%astgc
-                    read(unit, *, iostat=eof) omad_db(it)%astlbl
-                    read(unit, *, iostat=eof) omad_db(it)%astlig
-                    read(unit, *, iostat=eof) omad_db(it)%cn
-                    read(unit, *, iostat=eof) omad_db(it)%cp
-                    read(unit, *, iostat=eof) omad_db(it)%cs
-                end do
-            endif
-            close (unit)
-            
-            !xwalk fertdb_cbn(it)%omad%manure_name to omad_db(it)%manure_name
-
-            do i = 1, size(fertdb_cbn)
-              do it = 1, size(omad_db)
-                if (fertdb_cbn(i)%omad%manure_name == omad_db(it)%manure_name) then
-                  fertdb_cbn(i)%omad = omad_db(it)
-                  exit  ! Stop searching once a match is found
-                end if
-              end do
+            allocate (manure_db(0:imax))
+            rewind(unit)
+            read(unit,'(A)',iostat=eof) header
+            do it = 1, imax
+                read(unit,'(A)',iostat=eof) csv_line
+                if (eof < 0) exit
+                read(csv_line,*) &
+                     manure_db(it)%manure_region, &
+                     manure_db(it)%manure_source, &
+                     manure_db(it)%manure_type, &
+                     manure_db(it)%pct_moisture, &
+                     manure_db(it)%pct_solids, &
+                     manure_db(it)%total_c, &
+                     manure_db(it)%total_n, &
+                     manure_db(it)%inorganic_n, &
+                     manure_db(it)%organic_n, &
+                     manure_db(it)%total_p2o5, &
+                     manure_db(it)%inorganic_p2o5, &
+                     manure_db(it)%organic_p2o5, &
+                     manure_db(it)%inorganic_p, &
+                     manure_db(it)%organic_p, &
+                     manure_db(it)%solids, &
+                     manure_db(it)%water, &
+                     manure_db(it)%units, &
+                     manure_db(it)%sample_size, &
+                     manure_db(it)%summary_level, &
+                     manure_db(it)%data_source
+                manure_db(it)%manure_name = trim(manure_db(it)%manure_region)//trim(manure_db(it)%manure_source)//"_"// &
+                     trim(manure_db(it)%manure_type)
             end do
+            close (unit)
+
+            db_mx%manureparm = imax
+
+            ! crosswalk manure content records to entries loaded from fertilizer_ext.frt
+            if (size(fertdb_cbn) > 0 .and. size(manure_db) > 0) then
+              do i = 1, size(fertdb_cbn)
+                do it = 1, size(manure_db)
+                  if (trim(fertdb_cbn(i)%manure_content%manure_name) == trim(manure_db(it)%manure_name)) then
+                    fertdb_cbn(i)%manure_content = manure_db(it)
+                    exit  ! Stop searching once a match is found
+                  end if
+                end do
+              end do
+            end if
         endif
              
       return


### PR DESCRIPTION
## Summary
- extend `manure_content` data structure with attributes from the CSV defaults
- load `fp5-manure-content-defaults-swat.csv` in manure parameter reader
- drop unused variable for old `omad.txt` parsing
- remove unused legacy fields from manure content type
- crosswalk fertilizer records with manure region/source/type
- rename `omad` references to clearer `manure_content`
- remove reading of manure.frt and rename manure_content_db to manure_db

## Testing
- `cmake -S swatplus_ug -B swatplus_ug/build` *(fails: No CMAKE_Fortran_COMPILER found)*

------
https://chatgpt.com/codex/tasks/task_e_686ecace48f88333aa4ea119b3ae2bdb