### PR TITLE
Fix manure content field handling

### DIFF
--- a/src/fertilizer_data_module.f90
+++ b/src/fertilizer_data_module.f90
@@ -44,7 +44,7 @@
         type(fertilizer_db) :: base     !! base fertilizer data
         character(len=16) ::  name = " "  !! e.g., Midwest_Beef_Liquid
         character(len=64) ::  csv = " "  !! e.g., Midwest_Beef_Liquid
-        type (manure_attributes), dimension(:),allocatable :: manucontent !! manure attributes from csv file
+        type(manure_attributes) :: manucontent !! manure attributes from a single csv record
         character(len=16) :: pest = ""  !! pest.man name
         character(len=16) :: path = ""  !! path.man name
         character(len=16) :: salt = ""  !! salt.man name

--- a/src/manure_parm_read.f90
+++ b/src/manure_parm_read.f90
@@ -71,6 +71,7 @@
               do i = 1, size(manure_db)
                 do it = 1, size(manure_csv)
                   if (trim(manure_db(i)%csv) == trim(manure_csv(it)%manure_name)) then
+                    ! store attributes from matching csv record
                     manure_db(i)%manucontent = manure_csv(it)
                     exit  ! Stop searching once a match is found
                   end if


### PR DESCRIPTION
## Summary
- treat `manucontent` in `manure_database` as a scalar record
- store manure content using a direct scalar assignment

## Testing
- `cmake -B build` *(fails: No CMAKE_Fortran_COMPILER could be found)*

------
https://chatgpt.com/codex/tasks/task_e_68713ce09cdc8333ba2adc664a796125