### PR TITLE
Fix unit variable in manure_parm_read

### DIFF
--- a/src/manure_parm_read.f90
+++ b/src/manure_parm_read.f90
@@ -38,7 +38,7 @@
             rewind(unit)
             read(unit,'(A)',iostat=eof) header
             do it = 1, imax
-                read (107,*,iostat=eof) manure_csv(it)%manure_region, &
+                read (unit,*,iostat=eof) manure_csv(it)%manure_region, &
                      manure_csv(it)%manure_source, &
                      manure_csv(it)%manure_type, &
                      manure_csv(it)%pct_moisture, &


### PR DESCRIPTION
## Summary
- use the `unit` variable in `manure_parm_read` instead of hard-coded unit number

## Testing
- `cmake -B build` *(fails: No CMAKE_Fortran_COMPILER could be found)*

------
https://chatgpt.com/codex/tasks/task_e_68713ce1845483339a129ba621464c99