### PR TITLE
Graceful default for salt irrigation

### DIFF
--- a/src/salt_hru_init.f90
+++ b/src/salt_hru_init.f90
@@ -56,7 +56,14 @@
             water_volume = (soil(ihru)%phys(ly)%st/1000.) * hru_area_m2
             cs_soil(ihru)%ly(ly)%salt(isalt) = (salt_soil_ini(isalt_db)%soil(isalt)/1000.) * water_volume / hru(ihru)%area_ha !g/m3 --> kg/ha
           end do
-          cs_irr(ihru)%saltc(isalt) = salt_water_irr(isalt_db)%water(isalt) !g/m3 concentration
+          ! irrigation water salt concentration. salt_water_irr is allocated
+          ! with zero values when no salt_irrigation file is provided (see
+          ! salt_irr_read).
+          if (allocated(salt_water_irr)) then
+            cs_irr(ihru)%saltc(isalt) = salt_water_irr(isalt_db)%water(isalt)
+          else
+            cs_irr(ihru)%saltc(isalt) = 0.
+          end if
         end do
         
         ! loop for salt mineral fractions

--- a/src/salt_irr_read.f90
+++ b/src/salt_irr_read.f90
@@ -17,6 +17,9 @@
       eof = 0
       
       !read salt data for outside irrigation water
+      !if the file is missing, a single default profile with zero
+      !concentration is created so initialization routines can
+      !safely reference salt_water_irr
       inquire (file="salt_irrigation", exist=i_exist)
       if (i_exist) then
         do
@@ -54,7 +57,13 @@
           close (107)
           exit
         end do
-      end if
+        else
+          ! No salt_irrigation file supplied - allocate a single default record
+          ! so other routines can safely assume salt_water_irr is allocated.
+          allocate (salt_water_irr(1))
+          allocate (salt_water_irr(1)%water(cs_db%num_salts), source = 0.)
+          salt_water_irr(1)%name = 'default'
+        end if
       
       return
       end subroutine salt_irr_read


### PR DESCRIPTION
## Summary
- allocate a default zeroed `salt_water_irr` record when no `salt_irrigation` file is found
- guard irrigation initialization with `allocated(salt_water_irr)`
- document fallback behavior in comments

## Testing
- `cmake -B build` *(fails: No CMAKE_Fortran_COMPILER could be found)*

------
https://chatgpt.com/codex/tasks/task_e_68751c4c78cc83339b31037166b8ff32