### PR TITLE
Graceful default for salt irrigation

### DIFF
--- a/src/cs_cha_read.f90
+++ b/src/cs_cha_read.f90
@@ -23,7 +23,7 @@
       
       !open and read file contents
       inquire (file="cs_channel.ini", exist=i_exist)
-      if (i_exist .or. "cs_channel.ini" /= "null") then
+      if (i_exist) then
         do
           open (107,file="cs_channel.ini")
           read (107,*,iostat=eof) titldum
@@ -58,7 +58,14 @@
           close (107)
           exit
         end do
-      end if
+        else
+          ! If cs_channel.ini is missing, create a single default record with
+          ! zero concentrations so downstream initialization can proceed.
+          db_mx%cs_cha_ini = 1
+          allocate (cs_cha_ini(1))
+          allocate (cs_cha_ini(1)%conc(cs_db%num_cs), source = 0.)
+          cs_cha_ini(1)%name = 'default'
+        end if
 
       !determine if daily channel concentrations and loads should be output
       inquire (file="cs_streamobs", exist=i_exist)

--- a/src/salt_cha_read.f90
+++ b/src/salt_cha_read.f90
@@ -22,7 +22,7 @@
       
       !read all export coefficient data
       inquire (file="salt_channel.ini", exist=i_exist)
-      if (i_exist .or. "salt_channel.ini" /= "null") then
+      if (i_exist) then
         do
           open (107,file="salt_channel.ini")
           read (107,*,iostat=eof) titldum
@@ -57,7 +57,15 @@
           close (107)
           exit
         end do
-      end if
+        else
+          ! If no salt_channel.ini file is supplied, allocate a single
+          ! default record with zero concentrations so other routines can
+          ! safely reference salt_cha_ini.
+          db_mx%salt_cha_ini = 1
+          allocate (salt_cha_ini(1))
+          allocate (salt_cha_ini(1)%conc(cs_db%num_salts), source = 0.)
+          salt_cha_ini(1)%name = 'default'
+        end if
 
       return
       end subroutine salt_cha_read

--- a/src/salt_hru_init.f90
+++ b/src/salt_hru_init.f90
@@ -56,7 +56,14 @@
             water_volume = (soil(ihru)%phys(ly)%st/1000.) * hru_area_m2
             cs_soil(ihru)%ly(ly)%salt(isalt) = (salt_soil_ini(isalt_db)%soil(isalt)/1000.) * water_volume / hru(ihru)%area_ha !g/m3 --> kg/ha
           end do
-          cs_irr(ihru)%saltc(isalt) = salt_water_irr(isalt_db)%water(isalt) !g/m3 concentration
+          ! irrigation water salt concentration. salt_water_irr is allocated
+          ! with zero values when no salt_irrigation file is provided (see
+          ! salt_irr_read).
+          if (allocated(salt_water_irr)) then
+            cs_irr(ihru)%saltc(isalt) = salt_water_irr(isalt_db)%water(isalt)
+          else
+            cs_irr(ihru)%saltc(isalt) = 0.
+          end if
         end do
         
         ! loop for salt mineral fractions

--- a/src/salt_irr_read.f90
+++ b/src/salt_irr_read.f90
@@ -17,6 +17,9 @@
       eof = 0
       
       !read salt data for outside irrigation water
+      !if the file is missing, a single default profile with zero
+      !concentration is created so initialization routines can
+      !safely reference salt_water_irr
       inquire (file="salt_irrigation", exist=i_exist)
       if (i_exist) then
         do
@@ -54,7 +57,13 @@
           close (107)
           exit
         end do
-      end if
+        else
+          ! No salt_irrigation file supplied - allocate a single default record
+          ! so other routines can safely assume salt_water_irr is allocated.
+          allocate (salt_water_irr(1))
+          allocate (salt_water_irr(1)%water(cs_db%num_salts), source = 0.)
+          salt_water_irr(1)%name = 'default'
+        end if
       
       return
       end subroutine salt_irr_read

--- a/src/sd_hydsed_init.f90
+++ b/src/sd_hydsed_init.f90
@@ -286,8 +286,13 @@
           ich_ini = sd_dat(ichdat)%init
           isalt_ini = sd_init(ich_ini)%salt
           do isalt=1,cs_db%num_salts
-            ch_water(ich)%saltc(isalt) = salt_cha_ini(isalt_ini)%conc(isalt) !g/m3
-            ch_water(ich)%salt(isalt) = (salt_cha_ini(isalt_ini)%conc(isalt)/1000.) * tot_stor(ich)%flo !kg
+            if (allocated(salt_cha_ini)) then
+              ch_water(ich)%saltc(isalt) = salt_cha_ini(isalt_ini)%conc(isalt) !g/m3
+            else
+              ! fall back to zero concentration when no salt_channel.ini was provided
+              ch_water(ich)%saltc(isalt) = 0.
+            end if
+            ch_water(ich)%salt(isalt) = (ch_water(ich)%saltc(isalt)/1000.) * tot_stor(ich)%flo !kg
           enddo
         enddo
       endif
@@ -299,10 +304,15 @@
           ichdat = ob(iob)%props
           ich_ini = sd_dat(ichdat)%init
           ics_ini = sd_init(ich_ini)%cs
-          do ics=1,cs_db%num_cs
-            ch_water(ich)%csc(ics) = cs_cha_ini(ics_ini)%conc(ics)
-            ch_water(ich)%cs(ics) = (cs_cha_ini(ics_ini)%conc(ics)/1000.) * tot_stor(ich)%flo !kg
-          enddo
+            do ics=1,cs_db%num_cs
+              if (allocated(cs_cha_ini)) then
+                ch_water(ich)%csc(ics) = cs_cha_ini(ics_ini)%conc(ics)
+              else
+                ! default to zero concentration when no cs_channel.ini was provided
+                ch_water(ich)%csc(ics) = 0.
+              end if
+              ch_water(ich)%cs(ics) = (ch_water(ich)%csc(ics)/1000.) * tot_stor(ich)%flo !kg
+            enddo
         enddo
             endif
       


### PR DESCRIPTION
## Summary
- allocate a default zeroed `salt_water_irr` record when no `salt_irrigation` file is found
- guard irrigation initialization with `allocated(salt_water_irr)`
- document fallback behavior in comments
- allocate default records for missing channel salt/constituent input files
- guard channel initialization when these files are absent

## Testing
- `cmake -B build` *(fails: No CMAKE_Fortran_COMPILER could be found)*

------
https://chatgpt.com/codex/tasks/task_e_68751c4c78cc83339b31037166b8ff32