### PR TITLE
Assign default percolation value

### DIFF
--- a/src/path_parm_read.f90
+++ b/src/path_parm_read.f90
@@ -20,6 +20,7 @@
       inquire (file=in_parmdb%pathcom_db,exist=i_exist)
       if (.not. i_exist .or. in_parmdb%pathcom_db == "null") then
          allocate (path_db(0:0))
+         path_db(0)%perco = 1.0      !! assume percolation when no database found
       else
       do
         open (107,file=in_parmdb%pathcom_db)


### PR DESCRIPTION
## Summary
- give `path_db(0)` a default `perco` value when database file is absent

## Testing
- `python3 -m py_compile test/spcheck.py test/swat_output_to_csv_files.py`
- `cmake -B build` *(fails: No CMAKE_Fortran_COMPILER)*
- `ctest` *(fails: No test configuration file found)*


------
https://chatgpt.com/codex/tasks/task_e_68752ce56a548333a8c98f7fdbe615c7