### PR TITLE
Remove unused theta variable

### DIFF
--- a/src/path_ls_process.f90
+++ b/src/path_ls_process.f90
@@ -21,7 +21,6 @@
       real :: sol_die_gro = 0.
       real :: bacdiegrosol_out = 0.
       real :: bacdiegroplt_out = 0.
-      real :: theta
       real :: wash_off = 0. !               |pathogen wash off
 
       j = ihru


### PR DESCRIPTION
## Summary
- clean up unused `theta` variable from `path_ls_process`

## Testing
- `cmake -B build` *(fails: No CMAKE_Fortran_COMPILER could be found)*

------
https://chatgpt.com/codex/tasks/task_e_687543a6a82c8333822a06b07bb76f75