### PR TITLE
Initialize pathogen defaults when database missing

### DIFF
--- a/src/path_parm_read.f90
+++ b/src/path_parm_read.f90
@@ -20,7 +20,26 @@
       inquire (file=in_parmdb%pathcom_db,exist=i_exist)
       if (.not. i_exist .or. in_parmdb%pathcom_db == "null") then
          allocate (path_db(0:0))
-         path_db(0)%perco = 1.0      !! assume percolation when no database found
+         ! Set defaults so the model does not access uninitialized values when
+         ! pathogens are not simulated
+         path_db(0)%pathnm    = ""
+         path_db(0)%do_soln   = 0.
+         path_db(0)%gr_soln   = 0.
+         path_db(0)%do_sorb   = 0.
+         path_db(0)%gr_sorb   = 0.
+         path_db(0)%kd        = 0.
+         path_db(0)%t_adj     = 1.
+         path_db(0)%washoff   = 0.
+         path_db(0)%do_plnt   = 0.
+         path_db(0)%gr_plnt   = 0.
+         path_db(0)%fr_manure = 0.
+         path_db(0)%perco     = 1.0      !! assume percolation when no database found
+         path_db(0)%det_thrshd = 0.
+         path_db(0)%do_stream = 0.
+         path_db(0)%gr_stream = 0.
+         path_db(0)%do_res    = 0.
+         path_db(0)%gr_res    = 0.
+         path_db(0)%conc_min  = 0.
       else
       do
         open (107,file=in_parmdb%pathcom_db)


### PR DESCRIPTION
## Summary
- assign default values for `pathogen_db` when no pathogen database is found
- add a note that these defaults prevent uninitialized pathogen parameters

## Testing
- `python3 -m py_compile test/spcheck.py test/swat_output_to_csv_files.py`

------
https://chatgpt.com/codex/tasks/task_e_687543a4a2148333bc49ae1d793b5319