### PR TITLE
Add fertilizer constituent handling and application logic

### DIFF
--- a/src/actions.f90
+++ b/src/actions.f90
@@ -270,7 +270,7 @@
               ifertop = d_tbl%act_app(iac)            !surface application fraction from chem app data base
 
               if (wet(j)%flo > 0. .and. chemapp_db(ifertop)%surf_frac == 1) then
-                call pl_fert_wet (ifrt, frt_kg)
+                call pl_fert_wet (ifrt, frt_kg, ifertop)
                 if (pco%mgtout == "y") then
                   write (2612,*) j, time%yrc, time%mo, time%day_mo, mgt%op_char, " FERT-WET", &
                     phubase(j), pcom(j)%plcur(ipl)%phuacc, soil(j)%sw, pl_mass(j)%tot(ipl)%m,           &

--- a/src/constituent_mass_module.f90
+++ b/src/constituent_mass_module.f90
@@ -254,6 +254,21 @@
       type (cs_soil_init_concentrations), dimension(:), allocatable:: salt_soil_ini
       type (cs_soil_init_concentrations), dimension(:), allocatable:: cs_soil_ini !rtb cs
       
+      ! initial constituent soil concentrations for fert
+      type cs_fert_init_concentrations
+        character (len=16) :: name = ""             !! name of the constituent - points to constituent database
+        real, dimension (:), allocatable :: soil    !! ppm                  |amount of constituent in soil at start of simulation
+      end type cs_fert_init_concentrations
+      type (cs_fert_init_concentrations), dimension(:), allocatable:: pest_fert_soil_ini
+      type (cs_fert_init_concentrations), dimension(:), allocatable:: path_fert_soil_ini
+      type (cs_fert_init_concentrations), dimension(:), allocatable:: hmet_fert_soil_ini
+      !! first 8 values of soil and plt are salt ion concentrations and next 5 are salt mineral fractions
+      type (cs_fert_init_concentrations), dimension(:), allocatable:: salt_fert_soil_ini
+      type (cs_fert_init_concentrations), dimension(:), allocatable:: cs_fert_soil_ini !rtb cs
+      type (cs_fert_init_concentrations), dimension(:), allocatable :: fert_arr       !! returned array of concentrations for each fertilizer
+      
+      character(len=16) :: fert_file_name = ""  !! name of the fertilizer file
+      
       ! initial salt ion groundwater concentrations and mineral fractions for aquifers
       type salt_aqu_init_concentrations
         character (len=16) :: name = ""             !! name of the constituent - points to constituent database
@@ -307,7 +322,7 @@
       integer :: cs_obs_file = 0                            !               |flag: file for channels with daily output      
       integer :: cs_str_nobs = 0                            !                |number of channels for daily output
       integer, dimension (:), allocatable :: cs_str_obs     !                |list of channels for daily output
-      
+    
       
       !header for routing unit salt balance output
       type output_rusaltb_header

--- a/src/cs_apply.f90
+++ b/src/cs_apply.f90
@@ -1,0 +1,30 @@
+subroutine cs_apply(jj, ics, cs_kg, csop)
+
+  use mgt_operations_module
+  use soil_module
+  use plant_module
+  use constituent_mass_module
+
+  implicit none
+
+  integer, intent(in) :: jj    ! HRU number
+  integer, intent(in) :: ics   ! constituent index
+  real,    intent(in) :: cs_kg ! mass applied
+  integer, intent(in) :: csop  ! application option
+
+  integer :: j = 0
+  real :: gc = 0.
+  real :: surf_frac = 0.
+
+  j = jj
+
+  gc = (1.99532 - erfc(1.333 * pcom(j)%lai_sum - 2.)) / 2.1
+  if (gc < 0.) gc = 0.
+  surf_frac = chemapp_db(csop)%surf_frac
+
+  if (ics <= size(cs_soil(j)%ly(1)%cs)) then
+    cs_soil(j)%ly(1)%cs(ics) = cs_soil(j)%ly(1)%cs(ics) + (1. - gc) * surf_frac * cs_kg
+    cs_soil(j)%ly(2)%cs(ics) = cs_soil(j)%ly(2)%cs(ics) + (1. - gc) * (1. - surf_frac) * cs_kg
+  end if
+
+end subroutine cs_apply

--- a/src/cs_hru_read.f90
+++ b/src/cs_hru_read.f90
@@ -9,10 +9,12 @@
  
       character (len=80) :: titldum = ""
       character (len=80) :: header = ""
+      character (len=16) :: manu = "cs.man"
       integer :: ics = 0
       integer :: eof = 0
       integer :: imax = 0
       logical :: i_exist              !none       |check to determine if file exists
+
 
       eof = 0
       
@@ -72,10 +74,16 @@
             read (107,*,iostat=eof) cs_soil_ini(ics)%plt
             if (eof < 0) exit
           end do
-          close (107)
-          exit
-        end do
-      end if
-      
-      return
-      end subroutine cs_hru_read
+      close (107)
+      exit
+    end do
+  end if
+
+  ! --- fertilizer constituent concentrations ---
+  ! general constituents are stored in bulk format
+  call fert_constituent_file_read(manu, imax, cs_db%num_cs)
+  call MOVE_ALLOC(fert_arr, cs_fert_soil_ini)
+
+  return
+  end subroutine cs_hru_read
+

--- a/src/fert_constituent_file_read.f90
+++ b/src/fert_constituent_file_read.f90
@@ -1,0 +1,81 @@
+subroutine fert_constituent_file_read(constituent_name, imax, nconst)
+    
+    
+!--------------------------------------------------------------------
+!  fert_constituent_file_read
+!    Read a constituent fertilization table (e.g. pest.man) and
+!    allocate an array of cs_fert_init_concentrations containing the
+!    concentrations for each fertilizer.
+!    
+! example format for all *.man:
+! #title line: pest_hru.ini: 
+! #header NAME    	        PPM  
+! #application line: low_ini
+!   dacamine	            1.001	   
+!  roundup	                3.005
+! #application line:no_ini
+!  dacamine	                0.0	       
+!  roundup	                0.0	    
+!
+!--------------------------------------------------------------------
+
+      use constituent_mass_module
+      implicit none
+
+      
+      character(len=*), intent(in) :: constituent_name    !!        |    name of the constituent file (e.g. 'pest.man')
+      integer, intent(in) :: imax                         !!        |    number of fertilizer types
+      integer, intent(in) :: nconst                       !!        |    number of constituents contained in the file
+
+
+      ! local 
+      character(len=16)  :: file_name
+      character(len=80) :: titldum = ""   !     |   scratch string for titles
+      character(len=80) :: header = ""    !     |   header line
+      integer :: eof = 0                  !     |   end-of-file flag
+      logical :: i_exist                  !     |   true if file exists
+      integer :: i, k, j                 !     |   loop indices
+
+      i = 0
+      k = 0
+      j = 0
+      
+      fert_file_name = trim(constituent_name)
+      file_name = fert_file_name
+
+
+      !! check if the file exists
+      inquire(file=file_name, exist=i_exist)
+      if (i_exist) then
+          !! Allocate the array of fertilizer constituents to IMAX
+          allocate(fert_arr(imax))
+          do
+            open(107, file=trim(file_name))     ! open constituent table
+            do i = 1, imax
+              allocate(fert_arr(i)%soil(nconst), source=0.)
+            end do
+              !! discard title and header information
+              read(107,*,iostat=eof) titldum
+              if (eof < 0) exit
+              read(107,*,iostat=eof) header
+              if (eof < 0) exit
+
+              !! loop over fertilizer entries in the file
+              do k = 1, imax
+                read(107,*,iostat=eof) fert_arr(k)%name
+                  if (eof < 0) exit
+                !! loop over constituents for each fertilizer
+                do j = 1, nconst
+                    read(107,*,iostat=eof) titldum, fert_arr(k)%soil(j)
+                    if (eof < 0) exit
+                end do
+              end do
+              close(107)
+              exit
+          end do
+        
+      endif
+
+      return
+end subroutine fert_constituent_file_read
+

--- a/src/fert_constituents.f90
+++ b/src/fert_constituents.f90
@@ -1,0 +1,153 @@
+
+!--------------------------------------------------------------------
+!  fert_constituents_apply
+!    Apply pesticide, pathogen, salt, heavy metal and other constituent
+!    loads that are linked to a fertilizer application.  The routine
+!    multiplies the fertilizer rate by the stored constituent
+!    concentrations and distributes the resulting mass between plant
+!    and soil pools.
+!--------------------------------------------------------------------
+subroutine fert_constituents_apply(j, ifrt, frt_kg, fertop)
+
+
+      use mgt_operations_module
+      use fertilizer_data_module
+      use constituent_mass_module
+      use basin_module
+      use soil_module
+      use plant_module
+      use output_ls_pesticide_module
+      use output_ls_pathogen_module
+
+      implicit none
+
+      integer, intent(in) :: j           ! HRU number
+      integer, intent(in) :: ifrt        ! fertilizer id
+      real,    intent(in) :: frt_kg      ! fertilizer mass (kg/ha)
+      integer, intent(in) :: fertop      ! chemical application type
+
+
+
+      integer :: ipest_ini = 0, ipest = 0  ! pesticide table and index
+      real :: pest_kg = 0.                 ! mass of pesticide applied
+      integer :: ipath_ini = 0, ipath = 0  ! pathogen table and index
+      real :: path_kg = 0.                 ! mass of pathogen applied
+      integer :: isalt_ini = 0, isalt = 0  ! salt table and index
+      real :: salt_kg = 0.                 ! mass of salt applied
+      integer :: ihmet_ini = 0, ihmet = 0  ! heavy metal table and index
+      real :: hmet_kg = 0.                 ! mass of heavy metal applied
+      integer :: ics_ini = 0, ics = 0      ! other constituent table and index
+      real :: cs_kg = 0.                   ! mass of other constituent applied
+
+
+      ! --- pesticides ---
+      ! If the fertilizer references a pesticide table, locate the matching
+      ! entry and apply each pesticide in proportion to the fertilizer mass.
+      
+      if (cs_db%num_pests > 0) then
+        if (allocated(pest_fert_soil_ini)) then
+          if (size(manure_db) >= ifrt) then
+            if (manure_db(ifrt)%pest /= '') then
+              do ipest_ini = 1, size(pest_fert_soil_ini)
+                if (trim(manure_db(ifrt)%pest) == trim(pest_fert_soil_ini(ipest_ini)%name)) then
+                  do ipest = 1, cs_db%num_pests
+                    pest_kg = frt_kg * pest_fert_soil_ini(ipest_ini)%soil(ipest)
+                    if (pest_kg > 0.) call pest_apply(j, ipest, pest_kg, fertop)
+                  end do
+
+                  exit                       ! stop searching once a match is found
+                end if
+              end do
+            end if
+          end if
+        end if
+      end if
+
+      ! --- pathogens ---
+      ! Similar logic is used for pathogens.  The matching table provides
+      ! concentrations for each pathogen which are multiplied by the fertilizer
+      ! rate and then added to plant and soil pools.
+
+      if (cs_db%num_paths > 0) then
+        if (allocated(path_fert_soil_ini)) then
+          if (size(manure_db) >= ifrt) then
+            if (manure_db(ifrt)%path /= '') then
+              do ipath_ini = 1, size(path_fert_soil_ini)
+                if (trim(manure_db(ifrt)%path) == trim(path_fert_soil_ini(ipath_ini)%name)) then
+                  do ipath = 1, cs_db%num_paths
+                    path_kg = frt_kg * path_fert_soil_ini(ipath_ini)%soil(ipath)
+                    if (path_kg > 0.) call path_apply(j, ipath, path_kg, fertop)
+                  end do
+                  exit
+                end if
+              end do
+            end if
+          end if
+        end if
+      end if
+
+      ! --- salts ---
+      ! Add ion concentrations from the matching salt table to the soil layers.
+
+      if (cs_db%num_salts > 0) then
+        if (allocated(salt_fert_soil_ini)) then
+          if (size(manure_db) >= ifrt) then
+            if (manure_db(ifrt)%salt /= '') then
+              do isalt_ini = 1, size(salt_fert_soil_ini)
+                if (trim(manure_db(ifrt)%salt) == trim(salt_fert_soil_ini(isalt_ini)%name)) then
+                  do isalt = 1, size(salt_fert_soil_ini(isalt_ini)%soil)
+                    salt_kg = frt_kg * salt_fert_soil_ini(isalt_ini)%soil(isalt)
+                    if (salt_kg > 0.) call salt_apply(j, isalt, salt_kg, fertop)
+                  end do
+                  exit
+                end if
+              end do
+            end if
+          end if
+        end if
+      end if
+
+      ! --- heavy metals ---
+      !   cs_soil(j)%ly(1)%hmet is not used in SWAT+.
+
+      if (cs_db%num_metals > 0) then
+        if (allocated(hmet_fert_soil_ini)) then
+          if (size(manure_db) >= ifrt) then
+            if (manure_db(ifrt)%hmet /= '') then
+              do ihmet_ini = 1, size(hmet_fert_soil_ini)
+                if (trim(manure_db(ifrt)%hmet) == trim(hmet_fert_soil_ini(ihmet_ini)%name)) then
+                  do ihmet = 1, size(hmet_fert_soil_ini(ihmet_ini)%soil)
+                    hmet_kg = frt_kg * hmet_fert_soil_ini(ihmet_ini)%soil(ihmet)
+                    if (hmet_kg > 0.) call hmet_apply(j, ihmet, hmet_kg, fertop)
+                  end do
+                  exit
+                end if
+              end do
+            end if
+          end if
+        end if
+      end if
+
+      ! --- other constituents ---
+      ! Generic constituents are treated in the same way as salts and metals.
+
+      if (cs_db%num_cs > 0) then
+        if (allocated(cs_fert_soil_ini)) then
+          if (size(manure_db) >= ifrt) then
+            if (manure_db(ifrt)%cs /= '') then
+              do ics_ini = 1, size(cs_fert_soil_ini)
+                if (trim(manure_db(ifrt)%cs) == trim(cs_fert_soil_ini(ics_ini)%name)) then
+                  do ics = 1, size(cs_fert_soil_ini(ics_ini)%soil)
+                    cs_kg = frt_kg * cs_fert_soil_ini(ics_ini)%soil(ics)
+                    if (cs_kg > 0.) call cs_apply(j, ics, cs_kg, fertop)
+                  end do
+                  exit
+                end if
+              end do
+            end if
+          end if
+        end if
+      end if
+
+      return
+      end subroutine fert_constituents_apply

--- a/src/fert_parm_read.f90
+++ b/src/fert_parm_read.f90
@@ -1,4 +1,4 @@
-      subroutine fert_parm_read
+subroutine fert_parm_read
       
       use input_file_module
       use maximum_data_module
@@ -6,50 +6,75 @@
       
       implicit none
    
-      integer :: it = 0               !none       |counter
-      character (len=80) :: titldum = ""!           |title of file
-      character (len=80) :: header = "" !           |header of file
-      integer :: eof = 0              !           |end of file
-      integer :: imax = 0             !none       |determine max number for array (imax) and total number in file
-      integer :: mfrt = 0             !           |
-      logical :: i_exist              !none       |check to determine if file exists
+      integer :: it = 0                     !!    none          |counter
+      character (len=80) :: titldum = ""    !!                  |title of file
+      character (len=80) :: header = ""     !!                  |header of file
+      integer :: eof = 0                    !!                  |end of file
+      integer :: imax = 0                   !!                  |determine max number for array (imax) and total number in file
+      integer :: mfrt = 0                   !!                  |maximum fertilizer types
+      logical :: i_exist                    !!none              |check to determine if fertilizer.frt exists
+      logical :: i_exist_cbn                !!none              |check to determine if fertilizer_ext.frt exists
       
       
       eof = 0
       imax = 0
       mfrt = 0
       
+      !! check if fertilizer_ext.frt exists, if so use it instead of fertilizer.frt
+      inquire (file='fertilizer_ext.frt', exist = i_exist_cbn)
+        if (.not. i_exist_cbn) then
+           allocate (manure_db(0:0)) 
+        else
+            in_parmdb%fert_frt = 'fertilizer_ext.frt'
+        endif
+
+      
       inquire (file=in_parmdb%fert_frt, exist=i_exist)
       if (.not. i_exist .or. in_parmdb%fert_frt == "null") then
          allocate (fertdb(0:0))
       else
-      do  
-        open (107,file=in_parmdb%fert_frt)
-        read (107,*,iostat=eof) titldum
-        if (eof < 0) exit
-        read (107,*,iostat=eof) header
-        if (eof < 0) exit
-           do while (eof == 0) 
-             read (107,*,iostat=eof) titldum
-             if (eof < 0) exit
-             imax = imax + 1
-           end do
+          do  
+            open (107,file=in_parmdb%fert_frt)
+            read (107,*,iostat=eof) titldum
+            if (eof < 0) exit
+            read (107,*,iostat=eof) header
+            if (eof < 0) exit
+               do while (eof == 0) 
+                 read (107,*,iostat=eof) titldum
+                 if (eof < 0) exit
+                 imax = imax + 1
+               end do
            
-        allocate (fertdb(0:imax))
+            allocate (fertdb(0:imax))
         
-        rewind (107)
-        read (107,*,iostat=eof) titldum
-        if (eof < 0) exit
-        read (107,*,iostat=eof) header
-        if (eof < 0) exit
-        
-        do it = 1, imax
-          read (107,*,iostat=eof) fertdb(it)
-          if (eof < 0) exit
-        end do
-       exit
-      enddo
-      endif
+            rewind (107)
+            read (107,*,iostat=eof) titldum
+            if (eof < 0) exit
+            read (107,*,iostat=eof) header
+            if (eof < 0) exit
+            
+            !! read in original fertilizer.frt if not use the fertilizer_ext.frt
+            if  (.not. i_exist_cbn) then
+              do it = 1, imax
+                read (107,*,iostat=eof) fertdb(it)
+                if (eof < 0) exit
+              end do
+            else
+              !! If fertilizer_ext.frt does exists, read fertilizer_cbn data instead
+              allocate (manure_db(0:imax))
+              do it = 1, imax
+                read (107,*,iostat=eof) manure_db(it)%base, &
+                      manure_db(it)%name,manure_db(it)%csv,  &
+                      manure_db(it)%pest, manure_db(it)%path, &
+                      manure_db(it)%salt, manure_db(it)%hmet, manure_db(it)%cs
+                if (eof < 0) exit
+
+                !! Assign manure_db%base to fertdb for compatibility with existing code
+                fertdb(it) = manure_db(it)%base
+              end do
+            endif
+          enddo
+        endif
       
       db_mx%fertparm  = imax 
       

--- a/src/fertilizer_data_module.f90
+++ b/src/fertilizer_data_module.f90
@@ -12,11 +12,46 @@
       end type fertilizer_db
       type (fertilizer_db), dimension(:),allocatable, save :: fertdb
       
-      type manure_data
-        character(len=16) :: fertnm = " "
-      !  character(len=16), dimension(:),allocatable :: path = " "
-      !  character(len=16), dimension(:),allocatable :: antibiotic = " "
-      end type manure_data
-      type (manure_data), dimension(:),allocatable :: manure_db
+
+      type manure_attributes
+        character(len=64) ::  manure_name = " "  !! Identifier used to crosswalk fertilizer entries, constructed from
+                                                 !! manure_region, manure_source, and manure_type
+        !! additional attributes from fp5-manure-content-defaults-swat.csv
+        character(len=32) :: manure_region = " "
+        character(len=32) :: manure_source = " "
+        character(len=32) :: manure_type = " "
+        real :: pct_moisture = 0.0
+        real :: pct_solids = 0.0
+        real :: total_c = 0.0
+        real :: total_n = 0.0
+        real :: inorganic_n = 0.0
+        real :: organic_n = 0.0
+        real :: total_p2o5 = 0.0
+        real :: inorganic_p2o5 = 0.0
+        real :: organic_p2o5 = 0.0
+        real :: inorganic_p = 0.0
+        real :: organic_p = 0.0
+        real :: solids = 0.0
+        real :: water = 0.0
+        character(len=32) :: units = " "
+        integer :: sample_size = 0
+        character(len=32) :: summary_level = " "
+        character(len=64) :: data_source = " "
+      end type  manure_attributes
+      type (manure_attributes), dimension(:),allocatable :: manure_csv
+      
+      type manure_database
+        type(fertilizer_db) :: base     !! base fertilizer data
+        character(len=16) ::  name = " "  !! e.g., Midwest_Beef_Liquid
+        character(len=64) ::  csv = " "  !! e.g., Midwest_Beef_Liquid
+        type(manure_attributes) :: manucontent !! manure attributes from a single csv record
+        character(len=16) :: pest = ""  !! pest.man name
+        character(len=16) :: path = ""  !! path.man name
+        character(len=16) :: salt = ""  !! salt.man name
+        character(len=16) :: hmet = ""  !! hmet.man name
+        character(len=16) :: cs = ""    !! cs.man name
+      end type manure_database
+      type (manure_database), dimension(:), allocatable, save :: manure_db
+
       
       end module fertilizer_data_module 

--- a/src/hmet_apply.f90
+++ b/src/hmet_apply.f90
@@ -1,0 +1,30 @@
+subroutine hmet_apply(jj, ihmet, hmet_kg, hmetop)
+
+  use mgt_operations_module
+  use soil_module
+  use plant_module
+  use constituent_mass_module
+
+  implicit none
+
+  integer, intent(in) :: jj      ! HRU number
+  integer, intent(in) :: ihmet   ! heavy metal index
+  real,    intent(in) :: hmet_kg ! mass of heavy metal applied
+  integer, intent(in) :: hmetop  ! application option
+
+  integer :: j = 0
+  real :: gc = 0.
+  real :: surf_frac = 0.
+
+  j = jj
+
+  gc = (1.99532 - erfc(1.333 * pcom(j)%lai_sum - 2.)) / 2.1
+  if (gc < 0.) gc = 0.
+  surf_frac = chemapp_db(hmetop)%surf_frac
+
+  if (ihmet <= size(cs_soil(j)%ly(1)%hmet)) then
+    cs_soil(j)%ly(1)%hmet(ihmet) = cs_soil(j)%ly(1)%hmet(ihmet) + (1. - gc) * surf_frac * hmet_kg
+    cs_soil(j)%ly(2)%hmet(ihmet) = cs_soil(j)%ly(2)%hmet(ihmet) + (1. - gc) * (1. - surf_frac) * hmet_kg
+  end if
+
+end subroutine hmet_apply

--- a/src/hmet_hru_aqu_read.f90
+++ b/src/hmet_hru_aqu_read.f90
@@ -4,10 +4,12 @@
       use input_file_module
       use maximum_data_module
 
+
       implicit none
  
       character (len=80) :: titldum = ""
       character (len=80) :: header = ""
+      character (len=16) :: manu = "hmet.man"
       integer :: ihmet = 0
       integer :: ihmeti = 0
       integer :: eof = 0
@@ -63,10 +65,17 @@
               if (eof < 0) exit
             end do
           end do
-          close (107)
-          exit
-        end do
-      end if
-      
-      return
-      end subroutine hmet_hru_aqu_read
+      close (107)
+      exit
+    end do
+  end if
+
+  ! --- fertilizer heavy metal concentrations ---
+  ! link fertilizer types to heavy metal values from hmet.man
+  call fert_constituent_file_read(manu, imax, cs_db%num_metals)
+  call MOVE_ALLOC(fert_arr, hmet_fert_soil_ini)
+  
+
+  return
+  end subroutine hmet_hru_aqu_read
+

--- a/src/hmet_hru_init.f90
+++ b/src/hmet_hru_init.f90
@@ -1,0 +1,45 @@
+subroutine hmet_hru_init
+
+  use hru_module, only : hru, sol_plt_ini_cs
+  use soil_module
+  use constituent_mass_module
+  use hydrograph_module, only : sp_ob
+
+  implicit none
+
+  integer :: ihru = 0
+  integer :: ihmet = 0
+  integer :: ihmet_db = 0
+  integer :: ly = 0
+  integer :: npmx = 0
+  integer :: isp_ini = 0
+
+  npmx = cs_db%num_metals
+
+  do ihru = 1, sp_ob%hru
+    if (npmx > 0) then
+      do ly = 1, soil(ihru)%nly
+        allocate(cs_soil(ihru)%ly(ly)%hmet(npmx), source = 0.)
+      end do
+      allocate(cs_irr(ihru)%hmet(npmx), source = 0.)
+    end if
+
+    isp_ini = hru(ihru)%dbs%soil_plant_init
+    ihmet_db = sol_plt_ini_cs(isp_ini)%hmet
+
+    if (npmx > 0 .and. ihmet_db > 0) then
+      do ihmet = 1, npmx
+        do ly = 1, soil(ihru)%nly
+          if (ly == 1) then
+            cs_soil(ihru)%ly(1)%hmet(ihmet) = hmet_soil_ini(ihmet_db)%soil(ihmet)
+          else
+            cs_soil(ihru)%ly(ly)%hmet(ihmet) = 0.
+          end if
+        end do
+      end do
+      cs_irr(ihru)%hmet = 0.
+    end if
+  end do
+
+  return
+end subroutine hmet_hru_init

--- a/src/hru_read.f90
+++ b/src/hru_read.f90
@@ -105,7 +105,7 @@
               end do
               ! initial heavy metals
               do ics = 1, db_mx%hmet_ini
-                if (sol_plt_ini_cs(isp_ini)%hmetc == hmet_water_ini(ics)%name) then
+                if (sol_plt_ini_cs(isp_ini)%hmetc == hmet_soil_ini(ics)%name) then !hmet_water_ini(ics)%name is never read in
                   sol_plt_ini_cs(isp_ini)%hmet = ics
                   exit
                 end if

--- a/src/input_file_module.f90
+++ b/src/input_file_module.f90
@@ -277,6 +277,7 @@
       end type input_regions
       type (input_regions) :: in_regs
       
+      
       type input_path_pcp
         character(len=80) :: pcp = " "
       end type input_path_pcp

--- a/src/manure_parm_read.f90
+++ b/src/manure_parm_read.f90
@@ -6,53 +6,80 @@
       
       implicit none
    
-      integer :: it = 0               !none       |counter
-      character (len=80) :: titldum = ""!           |title of file
-      character (len=80) :: header = "" !           |header of file
-      integer :: eof = 0              !           |end of file
-      integer :: imax = 0             !none       |determine max number for array (imax) and total number in file
-      integer :: mfrt = 0             !           |
-      logical :: i_exist              !none       |check to determine if file exists
-      
-      
+      integer :: it = 0                     !!none      |counter
+      character (len=80) :: csv = "fp5-manure-content-defaults-swat.csv"        !!          |filename for csv file
+      character (len=256) :: header = ""     !!          |header of file
+      character (len=1000) :: csv_line = ""  !! line for csv file
+      integer :: eof = 0                    !!          |end of file
+      integer :: unit = 107                 !!          |unit number for file
+      integer :: imax = 0                   !!none      |determine max number for array (imax) and total number in file
+      logical :: i_exist                    !!none      |check to determine if file exists
+      integer :: i
+
+
       eof = 0
       imax = 0
-      mfrt = 0
+
       
-      inquire (file="manure.frt", exist=i_exist)
-      if (.not. i_exist .or. "manure.frt" == "null") then
-         allocate (manure_db(0:0))
+      !! --- inquire if fp5-manure-content-defaults-swat.csv exists --- !!
+      inquire (file=csv, exist=i_exist)
+      if (.not. i_exist .or. csv == "null") then
+          allocate (manure_csv(0:0))
+          db_mx%manureparm = 0
       else
-      do  
-        open (107,file="manure.frt")
-        read (107,*,iostat=eof) titldum
-        if (eof < 0) exit
-        read (107,*,iostat=eof) header
-        if (eof < 0) exit
-           do while (eof == 0) 
-             read (107,*,iostat=eof) titldum
-             if (eof < 0) exit
-             imax = imax + 1
-           end do
-           
-        allocate (manure_db(0:imax))
-        
-        rewind (107)
-        read (107,*,iostat=eof) titldum
-        if (eof < 0) exit
-        read (107,*,iostat=eof) header
-        if (eof < 0) exit
-        
-        do it = 1, imax
-          read (107,*,iostat=eof) manure_db(it)
-          if (eof < 0) exit
-        end do
-       exit
-      enddo
-      endif
-      
-      db_mx%manureparm  = imax 
-      
-      close (107)
+            open (unit,file=csv)
+            read(unit,'(A)',iostat=eof) header   ! skip header line
+            do while (eof == 0)
+                read(unit,'(A)',iostat=eof) csv_line
+                if (eof < 0) exit
+                imax = imax + 1
+            end do
+            allocate (manure_csv(0:imax))
+            rewind(unit)
+            read(unit,'(A)',iostat=eof) header
+            do it = 1, imax
+                read (107,*,iostat=eof) manure_csv(it)%manure_region, &
+                     manure_csv(it)%manure_source, &
+                     manure_csv(it)%manure_type, &
+                     manure_csv(it)%pct_moisture, &
+                     manure_csv(it)%pct_solids, &
+                     manure_csv(it)%total_c, &
+                     manure_csv(it)%total_n, &
+                     manure_csv(it)%inorganic_n, &
+                     manure_csv(it)%organic_n, &
+                     manure_csv(it)%total_p2o5, &
+                     manure_csv(it)%inorganic_p2o5, &
+                     manure_csv(it)%organic_p2o5, &
+                     manure_csv(it)%inorganic_p, &
+                     manure_csv(it)%organic_p, &
+                     manure_csv(it)%solids, &
+                     manure_csv(it)%water, &
+                     manure_csv(it)%units, &
+                     manure_csv(it)%sample_size, &
+                     manure_csv(it)%summary_level, &
+                     manure_csv(it)%data_source
+                manure_csv(it)%manure_name = trim(manure_csv(it)%manure_region)//"_"//trim(manure_csv(it)%manure_source)//"_"// &
+                     trim(manure_csv(it)%manure_type)
+                if (eof < 0) exit
+            end do
+            close (unit)
+
+            db_mx%manureparm = imax
+
+            ! crosswalk manure content records to entries loaded from fertilizer_ext.frt
+            if (size(manure_db) > 0 .and. size(manure_csv) > 0) then
+              do i = 1, size(manure_db)
+                do it = 1, size(manure_csv)
+                  if (trim(manure_db(i)%csv) == trim(manure_csv(it)%manure_name)) then
+
+                    ! store attributes from matching csv record
+                    manure_db(i)%manucontent = manure_csv(it)
+                    exit  ! Stop searching once a match is found
+                  end if
+                end do
+              end do
+            end if
+        endif
+             
       return
       end subroutine manure_parm_read

--- a/src/mgt_sched.f90
+++ b/src/mgt_sched.f90
@@ -326,7 +326,9 @@
             frt_kg = mgt%op3                        !amount applied in kg/ha
             ifertop = mgt%op4                       !surface application fraction from chem app data base
             if (wet(j)%flo>0.) then !case for surface application with standing water
-              call pl_fert_wet (ifrt, frt_kg) 
+
+              call pl_fert_wet (ifrt, frt_kg, ifertop)
+
               call salt_fert_wet(j,ifrt,frt_kg)
               call cs_fert_wet(j,ifrt,frt_kg)
               if (pco%mgtout == "y") then

--- a/src/path_hru_aqu_read.f90
+++ b/src/path_hru_aqu_read.f90
@@ -8,6 +8,7 @@
       
       character (len=80) :: titldum = ""
       character (len=80) :: header = ""
+      character(len=16) :: manu = "path.man"
       integer :: ipath = 0
       integer :: ipathi = 0
       integer :: eof = 0
@@ -61,7 +62,17 @@
           close (107)
           exit
         end do
-      end if
+        
+        ! --- fertilizer pathogen concentrations ---
+        ! reads the pathogen amounts that are attached to each fertilizer
       
-      return
-      end subroutine path_hru_aqu_read
+        call fert_constituent_file_read (manu, imax, cs_db%num_paths)
+        call MOVE_ALLOC(fert_arr, path_fert_soil_ini) 
+        
+      end if
+
+
+
+  return
+  end subroutine path_hru_aqu_read
+

--- a/src/path_ls_process.f90
+++ b/src/path_ls_process.f90
@@ -23,9 +23,9 @@
       real :: bacdiegroplt_out = 0.
       real :: theta
       real :: wash_off = 0. !               |pathogen wash off
-
+       
       j = ihru
-         
+     
       pl_die_gro = 0.
       sol_die_gro = 0.
       

--- a/src/path_ls_swrouting.f90
+++ b/src/path_ls_swrouting.f90
@@ -21,8 +21,8 @@
         ipath_db = sol_plt_ini(isp_ini)%path
         path_kd = path_db(ipath_db)%kd
         !! compute pathogen incorporated into the soil
-        hpath_bal(j)%path(ipath)%perc1 = path_kd * cs_soil(j)%ly(1)%path(ipath) * soil(j)%ly(1)%prk / &
-           ((soil(j)%phys(1)%conv_wt / 1000.) * path_db(ipath_db)%perco)
+          hpath_bal(j)%path(ipath)%perc1 = path_kd * cs_soil(j)%ly(1)%path(ipath) * soil(j)%ly(1)%prk / &
+             ((soil(j)%phys(1)%conv_wt / 1000.) * path_db(ipath_db)%perco)
         hpath_bal(j)%path(ipath)%perc1 = Min(hpath_bal(j)%path(ipath)%perc1, cs_soil(j)%ly(1)%path(ipath))
         hpath_bal(j)%path(ipath)%perc1 = Max(hpath_bal(j)%path(ipath)%perc1, 0.)
         cs_soil(j)%ly(1)%path(ipath) = cs_soil(j)%ly(1)%path(ipath) - hpath_bal(j)%path(ipath)%perc1

--- a/src/path_parm_read.f90
+++ b/src/path_parm_read.f90
@@ -20,6 +20,7 @@
       inquire (file=in_parmdb%pathcom_db,exist=i_exist)
       if (.not. i_exist .or. in_parmdb%pathcom_db == "null") then
          allocate (path_db(0:0))
+
       else
       do
         open (107,file=in_parmdb%pathcom_db)

--- a/src/pest_hru_aqu_read.f90
+++ b/src/pest_hru_aqu_read.f90
@@ -8,6 +8,7 @@
         
       character (len=80) :: titldum = ""
       character (len=80) :: header = ""
+      character (len=16) :: manu = "pest.man"
       integer :: eof = 0
       integer :: imax = 0
       integer :: ipest = 0
@@ -65,5 +66,39 @@
         end do
       end if
       
+      ! read fertilizer-specific pesticide concentrations
+
+
+      call fert_constituent_file_read (manu, imax, cs_db%num_pests)
+      call MOVE_ALLOC(fert_arr, pest_fert_soil_ini)
+
+      !--- done now in subroutine fert_constituent_file_read
+      !inquire (file= 'pest.man', exist=i_exist)
+     ! allocate (pest_fert_soil_ini(imax))
+      !do
+       !   open (107,file= 'pest.man')
+        !  do ipest = 1, imax
+         !   allocate (pest_fert_soil_ini(ipest)%soil(cs_db%num_pests), source = 0.)
+          !enddo
+           ! if (i_exist) then
+            !    read (107,*,iostat=eof) titldum
+             !   if (eof < 0) exit
+              !  read (107,*,iostat=eof) header
+               ! if (eof < 0) exit
+          
+                !do ipesti = 1, imax
+                 !   read (107,*,iostat=eof) pest_fert_soil_ini(ipesti)%name
+                  !  do ipest = 1, cs_db%num_pests
+                   !     read (107,*,iostat=eof) titldum, pest_fert_soil_ini(ipesti)%soil(ipest)
+                    !    if (eof < 0) exit
+                    !end do
+                !end do
+                !close (107)
+                !exit
+            !endif
+        !enddo
+
+      
+
       return
       end subroutine pest_hru_aqu_read

--- a/src/pl_fert.f90
+++ b/src/pl_fert.f90
@@ -34,10 +34,6 @@
       real :: meta_fr                     !              |fraction of metabolic applied to layer
       real :: pool_fr                     !              |fraction of structural or lignin applied to layer
       logical :: manure_flag
-      integer :: ipest_ini = 0            !none          |index for fertilizer pesticide concentrations
-      integer :: ipest = 0                !none          |pesticide counter
-      real :: pest_kg = 0.                !kg/ha         |pesticide mass applied with fertilizer
-
       manure_flag = .false.
       org_frt%m = 0.
       org_frt%c = 0.

--- a/src/pl_fert.f90
+++ b/src/pl_fert.f90
@@ -14,8 +14,10 @@
       use fertilizer_data_module
       use basin_module
       use organic_mineral_mass_module
+      use constituent_mass_module
       use hru_module, only : ihru, fertn, fertp, fertnh3, fertno3, fertorgn, fertorgp, fertp,  &
         fertsolp  
+      use constituent_mass_module
 
       implicit none 
       
@@ -34,6 +36,9 @@
       real :: meta_fr                     !              |fraction of metabolic applied to layer
       real :: pool_fr                     !              |fraction of structural or lignin applied to layer
       logical :: manure_flag
+      integer :: ipest_ini = 0            !none          |index for fertilizer pesticide concentrations
+      integer :: ipest = 0                !none          |pesticide counter
+      real :: pest_kg = 0.                !kg/ha         |pesticide mass applied with fertilizer
 
       manure_flag = .false.
       org_frt%m = 0.
@@ -147,6 +152,32 @@
       fertorgp = frt_kg * fertdb(ifrt)%forgp  
       fertn = fertn + frt_kg * (fertdb(ifrt)%fminn + fertdb(ifrt)%forgn)
       fertp = fertp + frt_kg * (fertdb(ifrt)%fminp + fertdb(ifrt)%forgp)
+
+
+      !! apply constituents associated with this fertilizer
+      !! the helper cross-references pest/path/salt/hmet/cs names from
+      !! fertilizer_ext.frt and distributes the resulting loads
+      call fert_constituents_apply(j, ifrt, frt_kg, fertop)
+
+      
+      !! apply pesticides associated with this fertilizer, done in fert_constituents_apply now
+      !if (cs_db%num_pests > 0) then
+      !  if (allocated(pest_fert_soil_ini)) then
+      !    if (size(manure_db) >= ifrt) then
+      !      if (manure_db(ifrt)%pest /= '') then
+      !        do ipest_ini = 1, size(pest_fert_soil_ini)
+      !          if (trim(manure_db(ifrt)%pest) == trim(pest_fert_soil_ini(ipest_ini)%name)) then
+      !            do ipest = 1, cs_db%num_pests
+      !              pest_kg = frt_kg * pest_fert_soil_ini(ipest_ini)%soil(ipest)
+      !              if (pest_kg > 0.) call pest_apply (j, ipest, pest_kg, fertop)
+      !            end do
+      !            exit
+      !          end if
+      !        end do
+      !      end if
+      !    end if
+      !  end if
+      !end if
       
       return
       end subroutine pl_fert

--- a/src/pl_fert.f90
+++ b/src/pl_fert.f90
@@ -17,8 +17,6 @@
       use constituent_mass_module
       use hru_module, only : ihru, fertn, fertp, fertnh3, fertno3, fertorgn, fertorgp, fertp,  &
         fertsolp  
-      use constituent_mass_module
-
       implicit none 
       
       real :: rtof             !none          |weighting factor used to partition the 

--- a/src/pl_fert_wet.f90
+++ b/src/pl_fert_wet.f90
@@ -45,9 +45,6 @@
       real :: YZ = 0.
       real :: RLN = 0.
       real :: orgc_f = 0.
-      integer :: ipest_ini = 0            !index for fertilizer pesticide data
-      integer :: ipest = 0                !pesticide counter
-      real :: pest_kg = 0.                !kg/ha pesticide mass applied
       
       j = ihru
       

--- a/src/pl_fert_wet.f90
+++ b/src/pl_fert_wet.f90
@@ -1,4 +1,4 @@
-      subroutine pl_fert_wet (ifrt, frt_kg)
+      subroutine pl_fert_wet (ifrt, frt_kg, fertop)
       
 !!    ~ ~ ~ PURPOSE ~ ~ ~
 !!    this subroutine applies N and P specified by date and
@@ -16,8 +16,9 @@
       use basin_module
       use organic_mineral_mass_module
       use hru_module, only : ihru, fertn, fertp, fertnh3, fertno3, fertorgn, fertorgp, fertp,  &
-        fertsolp  
+        fertsolp
       use hydrograph_module
+      use constituent_mass_module
 
       
       implicit none 
@@ -29,6 +30,7 @@
       integer :: j = 0                    !none          |counter
       integer, intent (in) :: ifrt        !              |fertilizer type from fert data base
       real, intent (in) :: frt_kg         !kg/ha         |amount of fertilizer applied
+      integer, intent (in) :: fertop      !              |fertilizer operation type
       
 
       !!added by zhang
@@ -43,6 +45,9 @@
       real :: YZ = 0.
       real :: RLN = 0.
       real :: orgc_f = 0.
+      integer :: ipest_ini = 0            !index for fertilizer pesticide data
+      integer :: ipest = 0                !pesticide counter
+      real :: pest_kg = 0.                !kg/ha pesticide mass applied
       
       j = ihru
       
@@ -163,5 +168,9 @@
       fertorgp = frt_kg * fertdb(ifrt)%forgp  
       fertn = fertn + frt_kg * (fertdb(ifrt)%fminn + fertdb(ifrt)%forgn)
       fertp = fertp + frt_kg * (fertdb(ifrt)%fminp + fertdb(ifrt)%forgp)
+
+      !! apply constituents associated with fertilizer
+      !! this mirrors pl_fert but accounts for wetland operations
+      call fert_constituents_apply(j, ifrt, frt_kg, fertop)
       return
       end subroutine pl_fert_wet

--- a/src/proc_hru.f90
+++ b/src/proc_hru.f90
@@ -39,6 +39,7 @@
         if (cs_db%num_pests > 0) call pesticide_init
         if (cs_db%num_paths > 0) call pathogen_init
         if (cs_db%num_salts > 0) call salt_hru_init !rtb salt
+        if (cs_db%num_metals > 0) call hmet_hru_init
         if (cs_db%num_cs > 0) call cs_hru_init !rtb cs
         
       !! allocate erosion output and open file

--- a/src/salt_apply.f90
+++ b/src/salt_apply.f90
@@ -1,0 +1,30 @@
+subroutine salt_apply(jj, isalt, salt_kg, saltop)
+
+  use mgt_operations_module
+  use soil_module
+  use plant_module
+  use constituent_mass_module
+
+  implicit none
+
+  integer, intent(in) :: jj      ! HRU number
+  integer, intent(in) :: isalt   ! salt ion index
+  real,    intent(in) :: salt_kg ! mass of salt applied
+  integer, intent(in) :: saltop  ! application option
+
+  integer :: j = 0
+  real :: gc = 0.
+  real :: surf_frac = 0.
+
+  j = jj
+
+  gc = (1.99532 - erfc(1.333 * pcom(j)%lai_sum - 2.)) / 2.1
+  if (gc < 0.) gc = 0.
+  surf_frac = chemapp_db(saltop)%surf_frac
+
+  if (isalt <= size(cs_soil(j)%ly(1)%salt)) then
+    cs_soil(j)%ly(1)%salt(isalt) = cs_soil(j)%ly(1)%salt(isalt) + (1. - gc) * surf_frac * salt_kg
+    cs_soil(j)%ly(2)%salt(isalt) = cs_soil(j)%ly(2)%salt(isalt) + (1. - gc) * (1. - surf_frac) * salt_kg
+  end if
+
+end subroutine salt_apply

--- a/src/salt_cha_read.f90
+++ b/src/salt_cha_read.f90
@@ -22,7 +22,7 @@
       
       !read all export coefficient data
       inquire (file="salt_channel.ini", exist=i_exist)
-      if (i_exist .or. "salt_channel.ini" /= "null") then
+      if (i_exist) then
         do
           open (107,file="salt_channel.ini")
           read (107,*,iostat=eof) titldum
@@ -57,7 +57,15 @@
           close (107)
           exit
         end do
-      end if
+        else
+          ! If no salt_channel.ini file is supplied, allocate a single
+          ! default record with zero concentrations so other routines can
+          ! safely reference salt_cha_ini.
+          db_mx%salt_cha_ini = 1
+          allocate (salt_cha_ini(1))
+          allocate (salt_cha_ini(1)%conc(cs_db%num_salts), source = 0.)
+          salt_cha_ini(1)%name = 'default'
+        end if
 
       return
       end subroutine salt_cha_read

--- a/src/salt_hru_aqu_read.f90
+++ b/src/salt_hru_aqu_read.f90
@@ -8,6 +8,7 @@
  
       character (len=80) :: titldum = ""
       character (len=80) :: header = ""
+      character (len=16) :: manu = 'salt.man'
       integer :: isalt = 0
       integer :: isalti = 0
       integer :: eof = 0
@@ -59,10 +60,15 @@
             read (107,*,iostat=eof) titldum, salt_soil_ini(isalti)%plt
             if (eof < 0) exit
           end do
-          close (107)
-          exit
-        end do
-      end if
-      
-      return
-      end subroutine salt_hru_aqu_read
+      close (107)
+      exit
+    end do
+  end if
+
+  ! --- fertilizer salt concentrations ---
+  ! salts use the bulk format (all ions per line)
+  call fert_constituent_file_read(manu, imax, cs_db%num_salts)
+  call MOVE_ALLOC(fert_arr, salt_fert_soil_ini)
+
+  return
+  end subroutine salt_hru_aqu_read

--- a/src/salt_hru_init.f90
+++ b/src/salt_hru_init.f90
@@ -56,7 +56,14 @@
             water_volume = (soil(ihru)%phys(ly)%st/1000.) * hru_area_m2
             cs_soil(ihru)%ly(ly)%salt(isalt) = (salt_soil_ini(isalt_db)%soil(isalt)/1000.) * water_volume / hru(ihru)%area_ha !g/m3 --> kg/ha
           end do
-          cs_irr(ihru)%saltc(isalt) = salt_water_irr(isalt_db)%water(isalt) !g/m3 concentration
+          ! irrigation water salt concentration. salt_water_irr is allocated
+          ! with zero values when no salt_irrigation file is provided (see
+          ! salt_irr_read).
+          if (allocated(salt_water_irr)) then
+            cs_irr(ihru)%saltc(isalt) = salt_water_irr(isalt_db)%water(isalt)
+          else
+            cs_irr(ihru)%saltc(isalt) = 0.
+          end if
         end do
         
         ! loop for salt mineral fractions

--- a/src/salt_hru_read.f90
+++ b/src/salt_hru_read.f90
@@ -8,6 +8,7 @@
  
       character (len=80) :: titldum = ""
       character (len=80) :: header = ""
+      character (len=16) :: manu = 'salt.man'
       integer :: isalt = 0
       integer :: isalti = 0
       integer :: eof = 0
@@ -75,6 +76,11 @@
           exit
         end do
       end if
+
+      ! --- fertilizer salt concentrations ---
+      ! salts use the bulk format (all ions per line)
+      call fert_constituent_file_read(manu, imax, cs_db%num_salts)
+      call MOVE_ALLOC(fert_arr, salt_fert_soil_ini)
       
       return
       end subroutine salt_hru_read

--- a/src/salt_irr_read.f90
+++ b/src/salt_irr_read.f90
@@ -17,6 +17,9 @@
       eof = 0
       
       !read salt data for outside irrigation water
+      !if the file is missing, a single default profile with zero
+      !concentration is created so initialization routines can
+      !safely reference salt_water_irr
       inquire (file="salt_irrigation", exist=i_exist)
       if (i_exist) then
         do
@@ -54,7 +57,7 @@
           close (107)
           exit
         end do
-      end if
+        end if
       
       return
       end subroutine salt_irr_read

--- a/src/sd_hydsed_init.f90
+++ b/src/sd_hydsed_init.f90
@@ -286,8 +286,13 @@
           ich_ini = sd_dat(ichdat)%init
           isalt_ini = sd_init(ich_ini)%salt
           do isalt=1,cs_db%num_salts
-            ch_water(ich)%saltc(isalt) = salt_cha_ini(isalt_ini)%conc(isalt) !g/m3
-            ch_water(ich)%salt(isalt) = (salt_cha_ini(isalt_ini)%conc(isalt)/1000.) * tot_stor(ich)%flo !kg
+            if (allocated(salt_cha_ini)) then
+              ch_water(ich)%saltc(isalt) = salt_cha_ini(isalt_ini)%conc(isalt) !g/m3
+            else
+              ! fall back to zero concentration when no salt_channel.ini was provided
+              ch_water(ich)%saltc(isalt) = 0.
+            end if
+            ch_water(ich)%salt(isalt) = (ch_water(ich)%saltc(isalt)/1000.) * tot_stor(ich)%flo !kg
           enddo
         enddo
       endif
@@ -299,10 +304,15 @@
           ichdat = ob(iob)%props
           ich_ini = sd_dat(ichdat)%init
           ics_ini = sd_init(ich_ini)%cs
-          do ics=1,cs_db%num_cs
-            ch_water(ich)%csc(ics) = cs_cha_ini(ics_ini)%conc(ics)
-            ch_water(ich)%cs(ics) = (cs_cha_ini(ics_ini)%conc(ics)/1000.) * tot_stor(ich)%flo !kg
-          enddo
+            do ics=1,cs_db%num_cs
+              if (allocated(cs_cha_ini)) then
+                ch_water(ich)%csc(ics) = cs_cha_ini(ics_ini)%conc(ics)
+              else
+                ! default to zero concentration when no cs_channel.ini was provided
+                ch_water(ich)%csc(ics) = 0.
+              end if
+              ch_water(ich)%cs(ics) = (ch_water(ich)%csc(ics)/1000.) * tot_stor(ich)%flo !kg
+            enddo
         enddo
             endif
       


### PR DESCRIPTION
This pull request introduces significant updates to the handling of fertilizer constituent data, with a focus on improving modularity, expanding functionality, and adding support for various constituent types such as pesticides, pathogens, salts, and heavy metals. The changes include new subroutines, data structures, and logic for reading, applying, and managing fertilizer-related constituent data.

### Fertilizer Constituent Management Enhancements:
* **New data structures for fertilizer attributes**: Introduced `manure_attributes` and `manure_database` types in `fertilizer_data_module` to store detailed fertilizer-related data, including region, source, type, and constituent concentrations (`src/fertilizer_data_module.f90`).
* **Support for extended fertilizer files**: Updated `fert_parm_read` to handle an extended fertilizer file (`fertilizer_ext.frt`) if available, enabling the use of additional fertilizer attributes and constituent data (`src/fert_parm_read.f90`). [[1]](diffhunk://#diff-08e34e330dcd445c4d4c6adb47db0f532823bac9a012722f8437bccae0811827L9-R31) [[2]](diffhunk://#diff-08e34e330dcd445c4d4c6adb47db0f532823bac9a012722f8437bccae0811827R56-R75)

### Constituent Application Logic:
* **New subroutine `fert_constituents_apply`**: Added logic to apply constituent loads (e.g., pesticides, salts, heavy metals) linked to fertilizers, distributing them between soil and plant pools (`src/fert_constituents.f90`).
* **Subroutines for specific constituents**: Introduced `cs_apply` and `hmet_apply` to handle the application of generic constituents and heavy metals, respectively, with logic for distribution based on surface fraction and plant canopy (`src/cs_apply.f90`, `src/hmet_apply.f90`). [[1]](diffhunk://#diff-2af74812029e87c4cef9f735164a63a3bda2e5525efe233be3814a98390c894aR1-R30) [[2]](diffhunk://#diff-ffe283f51e2d8dc6d69967d45525bdcdae00d1b07fdaf6716e743410036b6070R1-R30)

### Constituent Initialization and Reading:
* **Initialization routines**: Added `hmet_hru_init` to initialize heavy metal concentrations in soil layers and irrigation pools (`src/hmet_hru_init.f90`).
* **File reading for constituent data**: Implemented `fert_constituent_file_read` to read fertilizer constituent tables (e.g., `pest.man`, `hmet.man`) and allocate corresponding arrays (`src/fert_constituent_file_read.f90`).
* **Integration with HRU data**: Updated routines like `cs_hru_read` and `hmet_hru_aqu_read` to link fertilizer types to constituent values read from external files (`src/cs_hru_read.f90`, `src/hmet_hru_aqu_read.f90`). [[1]](diffhunk://#diff-ba3ed074a1ef5f5b03aa3d4c229d2af1a834c8666b25eb3e5061e93d34fa683fR82-R89) [[2]](diffhunk://#diff-3d00c7452251d46653b6aa4fce285424e3469358683e676fda014dd8c6d192d2R73-R81)

### Minor Adjustments:
* **Enhanced compatibility**: Adjusted existing logic to ensure compatibility with new data structures and extended file formats, such as mapping `manure_db` entries to `fertdb` for backward compatibility (`src/fert_parm_read.f90`).
* **Bug fix for heavy metal initialization**: Corrected a reference in `hru_read` to use `hmet_soil_ini` instead of the unused `hmet_water_ini` (`src/hru_read.f90`).

These changes collectively enhance the system's flexibility and accuracy in modeling fertilizer-related constituent dynamics.