### PR TITLE
Add FORD headers and inline comments

### DIFF
--- a/src/albedo.f90
+++ b/src/albedo.f90
@@ -1,7 +1,8 @@
+!!@summary Compute daily albedo for the current HRU
+!!@description Calculates HRU albedo using plant cover and snow depth
+!! from SWAT manual equations.
+!!@arguments None
       subroutine albedo
-!!    ~ ~ ~ PURPOSE ~ ~ ~
-!!    this subroutine calculates albedo in the HRU for the day
-!!
 
       use hru_module, only : hru, ihru, albday
       use soil_module
@@ -10,10 +11,10 @@
       
       implicit none
         
-      real :: cej = 0.  !none           |constant
-      real :: eaj = 0.  !none           |soil cover index      
-      integer :: j = 0  ! none          |HRU number
-      real :: cover = 0.  !kg/ha          |soil cover
+      real :: cej = 0.  !!none | constant
+      real :: eaj = 0.  !!none | soil cover index
+      integer :: j = 0  !!none | HRU number
+      real :: cover = 0.  !!kg/ha | soil cover
       
       j = ihru
 
@@ -22,11 +23,13 @@
       cover = pl_mass(j)%ab_gr_com%m + soil1(j)%rsd(1)%m
       eaj = Exp(cej * (cover + .1))   !! equation 2.2.16 in SWAT manual
 
+!! determine albedo based on snow cover
       if (hru(j)%sno_mm <= .5) then
         !! equation 2.2.14 in SWAT manual
         albday = soil(j)%ly(1)%alb
 
         !! equation 2.2.15 in SWAT manual
+!! adjust for plant cover
         if (pcom(j)%lai_sum > 0.) albday = .23 * (1. - eaj) + soil(j)%ly(1)%alb * eaj
       else
         !! equation 2.2.13 in SWAT manual

--- a/src/allocate_parms.f90
+++ b/src/allocate_parms.f90
@@ -1,12 +1,8 @@
+!!@summary Allocate model parameter arrays
+!!@description Reserves memory for hydrologic, management, and output
+!! arrays and sets default values.
+!!@arguments None
       subroutine allocate_parms
-!!    ~ ~ ~ PURPOSE ~ ~ ~
-!!    this subroutine allocates array sizes
-
-!!    ~ ~ ~ INCOMING VARIABLES ~ ~ ~
-!!    name        |units         |definition
-!!    ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~
-!!    mhyd        |none          |max number of hydrographs
-!!    ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~
 
       use hru_module      
       use time_module
@@ -14,21 +10,21 @@
       use constituent_mass_module
 
       implicit none
-      
-      integer :: mhru = 0
-      integer :: mch = 0
-      integer :: mpc = 0
+
+      integer :: mhru = 0  !!none | number of HRUs
+      integer :: mch = 0   !!none | number of channels
+      integer :: mpc = 0   !!none | plant community size
       
 !! initialize variables    
       mhyd = 1  !!added for jaehak vars
       mhru = sp_ob%hru
       mch = sp_ob%chan
 
-!!    drains
+!! allocate drainage variables
       allocate (wnan(10), source = 0.)
       allocate (ranrns_hru(mhru), source = 0.)
-      
-      !dimension plant arrays used each day and not saved
+
+!! allocate daily plant arrays
        mpc = 20
        allocate (uno3d(mpc), source = 0.)
        allocate (uapd(mpc), source = 0.)
@@ -40,12 +36,12 @@
        allocate (epmax(mpc), source = 0.)
        epmax = 0.
 
-!!    arrays for plant communities
+!! arrays for plant communities
       allocate (cvm_com(mhru), source = 0.)
       allocate (rsdco_plcom(mhru), source = 0.)
       allocate (percn(mhru), source = 0.)
 
-!! septic changes added 1/28/09 gsm
+!! septic system arrays
       allocate (i_sep(mhru), source = 0)
       allocate (sep_tsincefail(mhru), source = 0)
       allocate (qstemm(mhru), source = 0.)
@@ -59,17 +55,16 @@
       
       allocate (hhqday(mhru,time%step), source = 0.)
       
- !! arrays for management output (output.mgt)  
+!! arrays for management output (output.mgt)
       allocate (sol_sumno3(mhru), source = 0.)
       allocate (sol_sumsolp(mhru), source = 0.)
 
       allocate (iseptic(mhru), source = 0)
 
-!!    arrays which contain data related to years of rotation,
-!!    grazings per year, and HRUs
+!! arrays for rotation and grazing information
       allocate (grz_days(mhru), source = 0)
 
-!!    arrays which contain data related to HRUs
+!! arrays containing HRU data
       allocate (brt(mhru), source = 0.)
       allocate (canstor(mhru), source = 0.)
       allocate (cbodu(mhru), source = 0.)
@@ -209,10 +204,8 @@
        tillage_depth = 0.
        tillage_days = 0
        tillage_factor = 0.
-       
-      !! By Zhang for C/N cycling
-      !! ============================
-          
+
+!! initialize C/N cycling arrays
       call zero0
       call zero1
       call zero2


### PR DESCRIPTION
## Summary
- document `albedo` and `allocate_parms` with FORD headers
- convert declarations to inline comments and add process-flow comments

## Testing
- `cmake -B build` *(fails: No CMAKE_Fortran_COMPILER found)*

------
https://chatgpt.com/codex/tasks/task_e_687a57b56bc083339c0416d0e250c255