### PR TITLE
Add FORD headers and inline comments

### DIFF
--- a/src/albedo.f90
+++ b/src/albedo.f90
@@ -1,7 +1,8 @@
+!!@summary Compute daily albedo for the current HRU
+!!@description Calculates HRU albedo using plant cover and snow depth
+!! from SWAT manual equations.
+!!@arguments None
       subroutine albedo
-!!    ~ ~ ~ PURPOSE ~ ~ ~
-!!    this subroutine calculates albedo in the HRU for the day
-!!
 
       use hru_module, only : hru, ihru, albday
       use soil_module
@@ -10,10 +11,10 @@
       
       implicit none
         
-      real :: cej = 0.  !none           |constant
-      real :: eaj = 0.  !none           |soil cover index      
-      integer :: j = 0  ! none          |HRU number
-      real :: cover = 0.  !kg/ha          |soil cover
+      real :: cej = 0.  !!none | constant
+      real :: eaj = 0.  !!none | soil cover index
+      integer :: j = 0  !!none | HRU number
+      real :: cover = 0.  !!kg/ha | soil cover
       
       j = ihru
 
@@ -22,11 +23,13 @@
       cover = pl_mass(j)%ab_gr_com%m + soil1(j)%rsd(1)%m
       eaj = Exp(cej * (cover + .1))   !! equation 2.2.16 in SWAT manual
 
+!! determine albedo based on snow cover
       if (hru(j)%sno_mm <= .5) then
         !! equation 2.2.14 in SWAT manual
         albday = soil(j)%ly(1)%alb
 
         !! equation 2.2.15 in SWAT manual
+!! adjust for plant cover
         if (pcom(j)%lai_sum > 0.) albday = .23 * (1. - eaj) + soil(j)%ly(1)%alb * eaj
       else
         !! equation 2.2.13 in SWAT manual

--- a/src/allocate_parms.f90
+++ b/src/allocate_parms.f90
@@ -1,12 +1,8 @@
+!!@summary Allocate model parameter arrays
+!!@description Reserves memory for hydrologic, management, and output
+!! arrays and sets default values.
+!!@arguments None
       subroutine allocate_parms
-!!    ~ ~ ~ PURPOSE ~ ~ ~
-!!    this subroutine allocates array sizes
-
-!!    ~ ~ ~ INCOMING VARIABLES ~ ~ ~
-!!    name        |units         |definition
-!!    ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~
-!!    mhyd        |none          |max number of hydrographs
-!!    ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~
 
       use hru_module      
       use time_module
@@ -14,21 +10,21 @@
       use constituent_mass_module
 
       implicit none
-      
-      integer :: mhru = 0
-      integer :: mch = 0
-      integer :: mpc = 0
+
+      integer :: mhru = 0  !!none | number of HRUs
+      integer :: mch = 0   !!none | number of channels
+      integer :: mpc = 0   !!none | plant community size
       
 !! initialize variables    
       mhyd = 1  !!added for jaehak vars
       mhru = sp_ob%hru
       mch = sp_ob%chan
 
-!!    drains
+!! allocate drainage variables
       allocate (wnan(10), source = 0.)
       allocate (ranrns_hru(mhru), source = 0.)
-      
-      !dimension plant arrays used each day and not saved
+
+!! allocate daily plant arrays
        mpc = 20
        allocate (uno3d(mpc), source = 0.)
        allocate (uapd(mpc), source = 0.)
@@ -40,12 +36,12 @@
        allocate (epmax(mpc), source = 0.)
        epmax = 0.
 
-!!    arrays for plant communities
+!! arrays for plant communities
       allocate (cvm_com(mhru), source = 0.)
       allocate (rsdco_plcom(mhru), source = 0.)
       allocate (percn(mhru), source = 0.)
 
-!! septic changes added 1/28/09 gsm
+!! septic system arrays
       allocate (i_sep(mhru), source = 0)
       allocate (sep_tsincefail(mhru), source = 0)
       allocate (qstemm(mhru), source = 0.)
@@ -59,17 +55,16 @@
       
       allocate (hhqday(mhru,time%step), source = 0.)
       
- !! arrays for management output (output.mgt)  
+!! arrays for management output (output.mgt)
       allocate (sol_sumno3(mhru), source = 0.)
       allocate (sol_sumsolp(mhru), source = 0.)
 
       allocate (iseptic(mhru), source = 0)
 
-!!    arrays which contain data related to years of rotation,
-!!    grazings per year, and HRUs
+!! arrays for rotation and grazing information
       allocate (grz_days(mhru), source = 0)
 
-!!    arrays which contain data related to HRUs
+!! arrays containing HRU data
       allocate (brt(mhru), source = 0.)
       allocate (canstor(mhru), source = 0.)
       allocate (cbodu(mhru), source = 0.)
@@ -209,10 +204,8 @@
        tillage_depth = 0.
        tillage_days = 0
        tillage_factor = 0.
-       
-      !! By Zhang for C/N cycling
-      !! ============================
-          
+
+!! initialize C/N cycling arrays
       call zero0
       call zero1
       call zero2

--- a/src/aqu2d_init.f90
+++ b/src/aqu2d_init.f90
@@ -1,3 +1,7 @@
+!!@summary Initialize 2-D aquifer channels
+!!@description Sets up geomorphic linkage among channels and
+!! computes remaining length as they dry up for groundwater flow routing.
+!!@arguments None
       subroutine aqu2d_init
     
       use hydrograph_module
@@ -7,20 +11,22 @@
 
       implicit none
 
-      integer :: iaq = 0            !none       |counter
-      integer :: mfe = 0            !none       |my first element (channel with smallest area)
-      integer :: next1 = 0          !none       |counter
-      integer :: iprv = 0           !none       |counter 
-      integer :: ipts = 0           !none       |counter
-      integer :: npts = 0           !none       |counter
-      integer :: icha = 0           !none       |counter
-      integer :: ichd = 0           !none       |counter
-      integer :: iob = 0            !none       |counter
-      real :: sum_len = 0.          !km         |total length of channel in aquifer
-      real, dimension(:), allocatable :: next   !!next channel to dry up - sorted by drainage area
+      integer :: iaq = 0            !!none | counter
+      integer :: mfe = 0            !!none | my first element (channel with smallest area)
+      integer :: next1 = 0          !!none | counter
+      integer :: iprv = 0           !!none | counter
+      integer :: ipts = 0           !!none | counter
+      integer :: npts = 0           !!none | counter
+      integer :: icha = 0           !!none | counter
+      integer :: ichd = 0           !!none | counter
+      integer :: iob = 0            !!none | counter
+      real :: sum_len = 0.          !!km | total length of channel in aquifer
+      real, dimension(:), allocatable :: next   !!none | next channel to dry up - sorted by drainage area
       
-      !! set parameters needed to distribute gwflow to channels using geomorphical model
+!! initialize linkage for groundwater flow
+      !! exit if 2-D aquifer modeling is disabled
       if (db_mx%aqu2d <= 0) return
+!! loop through aquifers
       do iaq = 1, sp_ob%aqu
         !! set channel drainage areas
         allocate (aq_ch(iaq)%ch(aq_ch(iaq)%num_tot))
@@ -77,12 +83,13 @@
           aq_ch(iaq)%ch(icha)%len_left = sum_len
         end do
 
+        !! release temporary arrays
         deallocate (aqu_cha)
         deallocate (next)
         
       end do
 
-      !rtb salt/cs
+!! allocate constituent arrays for salt and other solutes
       if(cs_db%num_tot > 0) then
         allocate (aq_chcs(sp_ob%aqu))
         do iaq = 1, sp_ob%aqu
@@ -102,5 +109,6 @@
       endif
 
       
+!! finalize routine
       return
       end subroutine aqu2d_init

--- a/src/aqu2d_read.f90
+++ b/src/aqu2d_read.f90
@@ -1,3 +1,7 @@
+!!@summary Read 2-D aquifer configuration
+!!@description Loads channel element connections from input files for
+!! groundwater simulation.
+!!@arguments None
       subroutine aqu2d_read
     
       use hydrograph_module
@@ -6,28 +10,30 @@
       
       implicit none
       
-      character (len=80) :: titldum = ""!           |title of file
-      character (len=80) :: header = "" !           |header of file
-      character (len=16) :: namedum = ""!           |
-      integer :: eof = 0              !           |end of file
-      integer :: imax = 0             !none       |determine max number for array (imax) and total number in file
-      integer :: nspu = 0             !           |
-      logical :: i_exist              !none       |check to determine if file exists
-      integer :: i = 0                !none       |counter
-      integer :: isp = 0              !none       |counter
-      integer :: numb = 0             !           |
-      integer :: iaq = 0              !none       |counter
-      integer :: iaq_db = 0           !none       |counter
-      integer :: ielem1 = 0           !none       |counter
+      character (len=80) :: titldum = ""  !!none | title of file
+      character (len=80) :: header = ""   !!none | header of file
+      character (len=16) :: namedum = "" !!none | temporary name
+      integer :: eof = 0              !!none | end of file flag
+      integer :: imax = 0             !!none | max index in file
+      integer :: nspu = 0             !!none | number of subunits
+      logical :: i_exist              !!none | file exists flag
+      integer :: i = 0                !!none | counter
+      integer :: isp = 0              !!none | counter
+      integer :: numb = 0             !!none | dummy variable
+      integer :: iaq = 0              !!none | counter
+      integer :: iaq_db = 0           !!none | counter
+      integer :: ielem1 = 0           !!none | element count
 
       eof = 0
       imax = 0
       
-    !!read data for aquifer elements for 2-D groundwater model
+!! read data for aquifer elements for 2-D groundwater model
       inquire (file=in_link%aqu_cha, exist=i_exist)
       if (.not. i_exist .or. in_link%aqu_cha == "null" ) then
         allocate (aq_ch(0:0))
-      else 
+      else
+!! loop until end of file
+!! loop through file to count elements
       do
         if (eof < 0) exit
         open (107,file=in_link%aqu_cha)
@@ -43,12 +49,14 @@
         end do
       end do
 
+!! allocate arrays based on file count
       db_mx%aqu2d = imax
       allocate (aq_ch(sp_ob%aqu))
       rewind (107)
       read (107,*) titldum
       read (107,*) header
 
+!! read channel definitions
       do iaq_db = 1, imax
 
         read (107,*,iostat=eof) iaq, namedum, nspu
@@ -71,7 +79,9 @@
       end do
       end if
 
+!! close file and exit
       close (107)
       
+!! finalize routine
       return
       end subroutine aqu2d_read

--- a/src/aqu_hyds.f90
+++ b/src/aqu_hyds.f90
@@ -1,7 +1,9 @@
+!!@summary Update aquifer hydrologic variables
+!!@description Placeholder routine currently without implemented logic.
+!!@arguments None
       subroutine aqu_hyds
-  
-!!  nothing from nothing leaves nothing
       implicit none
 
+!! no operations performed
       return
       end subroutine aqu_hyds


### PR DESCRIPTION
## Summary
- document aquifer initialization and reading routines with FORD
- clarify aquifer hydrout subroutine as placeholder
- add inline units, descriptions and process comments

## Testing
- `cmake -B build` *(fails: No CMAKE_Fortran_COMPILER found)*

------
https://chatgpt.com/codex/tasks/task_e_687a57b56bc083339c0416d0e250c255