### PR TITLE
Update conditional_module.f90

### DIFF
--- a/src/conditional_module.f90
+++ b/src/conditional_module.f90
@@ -26,7 +26,7 @@
       end type actions_var
        
       type decision_table
-        character (len=25) :: name = ""                                 ! name of the decision table
+        character (len=40) :: name = ""                                 ! name of the decision table
         integer :: conds = 0                                            ! number of conditions
         integer :: alts = 0                                             ! number of alternatives
         integer :: acts = 0                                             ! number of actions


### PR DESCRIPTION
This pull request includes a single change to the `src/conditional_module.f90` file. The change increases the length of the `name` field in the `decision_table` type from 25 to 40 characters to fix xwalk with dtls.