### PR TITLE
Update wallo_withdraw.f90

### DIFF
--- a/src/wallo_withdraw.f90
+++ b/src/wallo_withdraw.f90
@@ -48,6 +48,8 @@
           wallod_out(iwallo)%dmd(idmd)%src(isrc)%withdr = wallod_out(iwallo)%dmd(idmd)%src(isrc)%withdr + dmd_m3
         else
           wallod_out(iwallo)%dmd(idmd)%src(isrc)%unmet = wallod_out(iwallo)%dmd(idmd)%src(isrc)%unmet + dmd_m3
+          wallod_out(iwallo)%dmd(idmd)%src(isrc)%unmet = Min (wallod_out(iwallo)%dmd(idmd)%src(isrc)%unmet,      &
+                                                                wallod_out(iwallo)%dmd(idmd)%src(isrc)%demand)
         end if
             
         !! reservoir source
@@ -63,6 +65,8 @@
             wallod_out(iwallo)%dmd(idmd)%src(isrc)%withdr = wallod_out(iwallo)%dmd(idmd)%src(isrc)%withdr + dmd_m3
           else
             wallod_out(iwallo)%dmd(idmd)%src(isrc)%unmet = wallod_out(iwallo)%dmd(idmd)%src(isrc)%unmet + dmd_m3
+            wallod_out(iwallo)%dmd(idmd)%src(isrc)%unmet = Min (wallod_out(iwallo)%dmd(idmd)%src(isrc)%unmet,      &
+                                                                wallod_out(iwallo)%dmd(idmd)%src(isrc)%demand)
           end if
          
         !! diversion inflow source
@@ -77,6 +81,8 @@
             wallod_out(iwallo)%dmd(idmd)%src(isrc)%withdr = wallod_out(iwallo)%dmd(idmd)%src(isrc)%withdr + dmd_m3
           else
             wallod_out(iwallo)%dmd(idmd)%src(isrc)%unmet = wallod_out(iwallo)%dmd(idmd)%src(isrc)%unmet + dmd_m3
+            wallod_out(iwallo)%dmd(idmd)%src(isrc)%unmet = Min (wallod_out(iwallo)%dmd(idmd)%src(isrc)%unmet,      &
+                                                                wallod_out(iwallo)%dmd(idmd)%src(isrc)%demand)
           end if
          
         !! aquifer source
@@ -84,13 +90,12 @@
           if(bsn_cc%gwflow == 0) then !proceed with original code
           j = wallo(iwallo)%dmd(idmd)%src_ob(isrc)%ob_num
           isrc_wallo = wallo(iwallo)%dmd(idmd)%src(isrc)%src
-          avail = (wallo(iwallo)%src(isrc_wallo)%limit_mon(time%mo) - aqu_d(j)%dep_wt)  * aqu_dat(j)%spyld
-          avail = avail * 10000. * aqu_prm(j)%area_ha     !m3 = 10,000*ha*m
+          avail = 10. * aqu_d(j)%stor * aqu_prm(j)%area_ha   !m3 = 10*ha*mm
           if (dmd_m3 < avail) then
             !! only have flow, no3, and minp(solp) for aquifer
             ht5%flo = dmd_m3
             aqu_d(j)%stor = aqu_d(j)%stor - (dmd_m3 / (10. * aqu_prm(j)%area_ha))  !mm = m3/(10.*ha)
-            rto =  (dmd_m3 / (10. * aqu_prm(j)%area_ha)) / aqu_d(j)%stor  !mm
+            rto =  Min(1., dmd_m3 / avail)
             ht5%no3 = rto * aqu_d(j)%no3_st
             aqu_d(j)%no3_st = (1. - rto) * aqu_d(j)%no3_st
             ht5%solp = rto * aqu_d(j)%minp
@@ -98,6 +103,8 @@
             wallod_out(iwallo)%dmd(idmd)%src(isrc)%withdr = wallod_out(iwallo)%dmd(idmd)%src(isrc)%withdr + dmd_m3
           else
             wallod_out(iwallo)%dmd(idmd)%src(isrc)%unmet = wallod_out(iwallo)%dmd(idmd)%src(isrc)%unmet + dmd_m3
+            wallod_out(iwallo)%dmd(idmd)%src(isrc)%unmet = Min (wallod_out(iwallo)%dmd(idmd)%src(isrc)%unmet,      &
+                                                                wallod_out(iwallo)%dmd(idmd)%src(isrc)%demand)
           end if
           elseif(bsn_cc%gwflow == 1) then !gwflow is active; determine pumping amounts from grid cells
             extracted = 0.
@@ -106,6 +113,8 @@
             call gwflow_ppag(wallo(iwallo)%dmd(idmd)%ob_num,dmd_m3,extracted,dmd_unmet)
             wallod_out(iwallo)%dmd(idmd)%src(isrc)%withdr = wallod_out(iwallo)%dmd(idmd)%src(isrc)%withdr + extracted
             wallod_out(iwallo)%dmd(idmd)%src(isrc)%unmet = wallod_out(iwallo)%dmd(idmd)%src(isrc)%unmet + dmd_unmet
+            wallod_out(iwallo)%dmd(idmd)%src(isrc)%unmet = Min (wallod_out(iwallo)%dmd(idmd)%src(isrc)%unmet,      &
+                                                                wallod_out(iwallo)%dmd(idmd)%src(isrc)%demand)
           endif
         
           !! canal diversion source (water removed from channel using point source)
@@ -126,6 +135,8 @@
             !store values
             wallod_out(iwallo)%dmd(idmd)%src(isrc)%withdr = wallod_out(iwallo)%dmd(idmd)%src(isrc)%withdr + withdraw
             wallod_out(iwallo)%dmd(idmd)%src(isrc)%unmet = wallod_out(iwallo)%dmd(idmd)%src(isrc)%unmet + unmet
+            wallod_out(iwallo)%dmd(idmd)%src(isrc)%unmet = Min (wallod_out(iwallo)%dmd(idmd)%src(isrc)%unmet,      &
+                                                                wallod_out(iwallo)%dmd(idmd)%src(isrc)%demand)
             
           !! unlimited source
           case ("unl")

--- a/src/wallo_withdraw.f90
+++ b/src/wallo_withdraw.f90
@@ -90,7 +90,7 @@
           if(bsn_cc%gwflow == 0) then !proceed with original code
           j = wallo(iwallo)%dmd(idmd)%src_ob(isrc)%ob_num
           isrc_wallo = wallo(iwallo)%dmd(idmd)%src(isrc)%src
-          avail = 10. * aqu_d(j)%stor * aqu_prm(j)%area_ha   !m3 = 10*ha*mm
+          avail = 10. * aqu_d(j)%stor * aqu_prm(j)%area_ha   ! Convert mm of storage over ha to total m³: m³ = 10 * ha * mm
           if (dmd_m3 < avail) then
             !! only have flow, no3, and minp(solp) for aquifer
             ht5%flo = dmd_m3


### PR DESCRIPTION
This pull request makes several improvements to the `wallo_withdraw` subroutine in `src/wallo_withdraw.f90` to ensure that the calculated unmet water demand for each source does not exceed the actual demand. The main change is the addition of a safeguard using the `Min` function after updating the `unmet` field, which is applied consistently across all relevant water source types. There are also minor improvements to the aquifer source calculation logic.

**Improvements to unmet demand calculation:**

* After updating the `unmet` field for each source, the code now ensures that `unmet` does not exceed the corresponding `demand` by applying the `Min` function. This change is applied for general sources, diversion inflow sources, aquifer sources (both with and without groundwater flow), and canal diversion sources. [[1]](diffhunk://#diff-5c53214458385d26e62d7e5519801cc074bb8a78174e080185e1fa5b7dff76e7R51-R52) [[2]](diffhunk://#diff-5c53214458385d26e62d7e5519801cc074bb8a78174e080185e1fa5b7dff76e7R68-R69) [[3]](diffhunk://#diff-5c53214458385d26e62d7e5519801cc074bb8a78174e080185e1fa5b7dff76e7R84-R107) [[4]](diffhunk://#diff-5c53214458385d26e62d7e5519801cc074bb8a78174e080185e1fa5b7dff76e7R116-R117) [[5]](diffhunk://#diff-5c53214458385d26e62d7e5519801cc074bb8a78174e080185e1fa5b7dff76e7R138-R139)

**Aquifer source calculation improvements:**

* The calculation of available water from the aquifer was updated to use a simplified formula (`avail = 10. * aqu_d(j)%stor * aqu_prm(j)%area_ha`), and the computation of the extraction ratio `rto` was modified to use `Min(1., dmd_m3 / avail)` for clarity and correctness.