### PR TITLE
Clarify active mineral P pool logic in comments

### DIFF
--- a/src/soil_nutcarb_init.f90
+++ b/src/soil_nutcarb_init.f90
@@ -74,8 +74,8 @@
         end if
         soil1(ihru)%mp(ly)%lab = soil1(ihru)%mp(ly)%lab * wt1   !! mg/kg => kg/ha
 
-        !! set active mineral P pool based on dynamic PSP MJW
-        if (bsn_cc%sol_P_model == 1) then 
+        !! set active mineral P pool based on dynamic PSP MJW, use only for top 2 layers, otherwise use 5 mg/kg as default
+        if (solt_db(isolt)%lab_p > 1.e-9 .and. ly < 3) then  !! mjw 2026 
           !! Allow Dynamic PSP Ratio
           !! convert to concentration
           solp = soil1(ihru)%mp(ly)%lab / wt1


### PR DESCRIPTION
This pull request updates the logic for initializing the active mineral phosphorus (P) pool in the `soil_nutcarb_init` subroutine. The main change is to use the dynamic PSP model only for the top two soil layers and only if the labile phosphorus value is significant; otherwise, a default value is used.

**Soil phosphorus initialization logic:**

* In `soil_nutcarb_init.f90`, the logic for setting the active mineral P pool now applies the dynamic PSP model only if `solt_db(isolt)%lab_p` is greater than `1.e-9` and the soil layer is one of the top two (`ly < 3`). Otherwise, it defaults to a set value.Updated comment for active mineral P pool logic to clarify conditions for using dynamic PSP.